### PR TITLE
Worker cannot quit if it encounters an error

### DIFF
--- a/fargate/upload-move/main.go
+++ b/fargate/upload-move/main.go
@@ -87,7 +87,6 @@ func main() {
 	for w := 1; w <= nrWorkers; w++ {
 		processWg.Add(1)
 		log.Debug("starting worker:", w)
-		w := int32(w)
 		go store.moveFile(w, walker)
 	}
 

--- a/fargate/upload-move/main.go
+++ b/fargate/upload-move/main.go
@@ -88,12 +88,7 @@ func main() {
 		processWg.Add(1)
 		log.Debug("starting worker:", w)
 		w := int32(w)
-		go func(workerId int32) {
-			err := store.moveFile(workerId, walker)
-			if err != nil {
-				log.Error("Error in Move Worker:", err)
-			}
-		}(w)
+		go store.moveFile(w, walker)
 	}
 
 	// Wait until all processors are completed.

--- a/fargate/upload-move/store.go
+++ b/fargate/upload-move/store.go
@@ -143,7 +143,7 @@ func (s *UploadMoveStore) manifestFileWalk(walker fileWalk) error {
 }
 
 // moveFile accepts an item from the channel and implements the move workflow for that item.
-func (s *UploadMoveStore) moveFile(workerId int32, items <-chan Item) {
+func (s *UploadMoveStore) moveFile(workerId int, items <-chan Item) {
 
 	// Close worker after it completes.
 	// This happens when the items channel closes.

--- a/fargate/upload-move/store.go
+++ b/fargate/upload-move/store.go
@@ -114,7 +114,7 @@ func (s *UploadMoveStore) manifestFileWalk(walker fileWalk) error {
 	})
 
 	log.Debug("In manifest file walk")
-
+	var pageNumber int
 	for p.HasMorePages() {
 		log.Debug("Getting page from dynamodb")
 
@@ -135,14 +135,15 @@ func (s *UploadMoveStore) manifestFileWalk(walker fileWalk) error {
 		for _, item := range pItems {
 			walker <- item
 		}
-
+		log.WithFields(log.Fields{"page_number": pageNumber, "item_count": out.Count}).Debug("added items to channel")
+		pageNumber++
 	}
 
 	return nil
 }
 
 // moveFile accepts an item from the channel and implements the move workflow for that item.
-func (s *UploadMoveStore) moveFile(workerId int32, items <-chan Item) error {
+func (s *UploadMoveStore) moveFile(workerId int32, items <-chan Item) {
 
 	// Close worker after it completes.
 	// This happens when the items channel closes.
@@ -167,7 +168,7 @@ func (s *UploadMoveStore) moveFile(workerId int32, items <-chan Item) error {
 					"manifest_id": item.ManifestId,
 					"upload_id":   item.UploadId,
 				}).Errorf("Error getting storage bucket for manifest: %v", err)
-			return err
+			continue
 		}
 
 		log.Debug(fmt.Sprintf("%d - %s - %s", workerId, item.UploadId, stOrgItem.storageBucket))
@@ -301,8 +302,6 @@ func (s *UploadMoveStore) moveFile(workerId int32, items <-chan Item) error {
 		}
 
 	}
-
-	return nil
 }
 
 // simpleCopyFile copy files between buckets using simple file copy method.


### PR DESCRIPTION
The move file workers exit if they cannot find a manifest for an item in DynamoDB. This is causing files to get stuck in the upload bucket in non-prod because we have orphan rows in the manifest file table. The number of orphan rows is greater than the number of workers, so all the workers quit early, leaving files unmoved.

PR removes the return from the worker function to emphasize that it should just `continue` if it encounters an error.