### PR TITLE
Remove redundant error logging.

### DIFF
--- a/fargate/upload-move/store.go
+++ b/fargate/upload-move/store.go
@@ -69,14 +69,17 @@ func (s *UploadMoveStore) GetManifestStorageBucket(manifestId string) (*storageO
 	// Get manifest from dynamodb based on id
 	manifest, err := s.dy.GetManifestById(context.Background(), TableName, manifestId)
 	if err != nil {
-		log.WithFields(log.Fields{"manifest_id": manifestId, "error": err}).Error("Error getting manifest")
+		err := fmt.Errorf("error getting manifest %s: %w", manifestId, err)
 		return nil, err
 	}
 
 	//var o dbTable.Organization
 	org, err := s.pg.GetOrganization(context.Background(), manifest.OrganizationId)
 	if err != nil {
-		log.WithFields(log.Fields{"manifest_id": manifestId, "organization_id": manifest.OrganizationId, "error": err}).Error("Error getting organization")
+		err := fmt.Errorf("error getting organization %d referenced in manifest %s: %w",
+			manifest.OrganizationId,
+			manifestId,
+			err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Same error is being logged more than once. 

PR only logs at the top level and wraps the error with additional info at the lower level.