### PR TITLE
Deduplicate files prior to insertion

### DIFF
--- a/lambda/upload/handler/handler_test.go
+++ b/lambda/upload/handler/handler_test.go
@@ -444,7 +444,8 @@ func generateManifestFilesAndEvents(params []tesManifestFileParams, manifestId s
 		}
 
 		sqsMessage := events.SQSMessage{
-			Body: string(evtJson),
+			MessageId: fmt.Sprintf("message-id-for-%s/%s", p.path, p.name),
+			Body:      string(evtJson),
 		}
 
 		sqsMessages = append(sqsMessages, sqsMessage)

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -28,6 +28,12 @@ import (
 	"time"
 )
 
+// seenFileUUIDs allows this Lambda to avoid trying to create the same file in Postgres more than once.
+// Can happen if AWS sends out the same S3 create object event more than once.
+// This could be a local variable to ImportFiles(). Just here in case the Lambda gets used more than once
+// we get a little more de-duplication.
+var seenFileUUIDs = map[uuid.UUID]bool{}
+
 // UploadHandlerStore provides the Queries interface and a db instance.
 type UploadHandlerStore struct {
 	pg            *UploadPgQueries
@@ -161,7 +167,7 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 				contextLogger.Debug("USING MERGED PACKAGE")
 				packageNodeId = fmt.Sprintf("N:package:%s", files[i].MergePackageId)
 			}
-
+			fileUUID := uuid.MustParse(files[i].UploadId)
 			file := pgdb.FileParams{
 				PackageId:  int(packageMap[packageNodeId].Id),
 				Name:       files[i].Name,
@@ -171,11 +177,17 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 				ObjectType: objectType.Source,
 				Size:       files[i].Size,
 				CheckSum:   files[i].ETag,
-				UUID:       uuid.MustParse(files[i].UploadId),
+				UUID:       fileUUID,
 				Sha256:     files[i].Sha256,
 			}
-
-			allFileParams = append(allFileParams, file)
+			// S3 may send a create object event
+			// for a given file more than once. If more than one instance
+			// ended up in this batch, here we ensure only one is sent
+			// to AddFiles() below.
+			if seen := seenFileUUIDs[fileUUID]; !seen {
+				seenFileUUIDs[fileUUID] = true
+				allFileParams = append(allFileParams, file)
+			}
 		}
 
 		returnedFiles, err := qtx.AddFiles(context.Background(), allFileParams)


### PR DESCRIPTION
PR uses a map to avoid passing the same file to `addFiles()` during the lifetime of one Lambda instance. It also logs any duplicate file uuids seen.