### PR TITLE
Feature / Support single-file uploads of 1 TB

### DIFF
--- a/fargate/upload-move/pkg/multipartUploader.go
+++ b/fargate/upload-move/pkg/multipartUploader.go
@@ -17,7 +17,7 @@ import (
 
 // maxPartSize constant for number of bits in 50 megabyte chunk
 // this corresponds with max file size of 500GB per file as copy can do max 10,000 parts.
-const maxPartSize = 50 * 1024 * 1024
+const maxPartSize = 105 * 1024 * 1024
 
 // nrCopyWorkers number of threads for multipart uploader
 const nrCopyWorkers = 10


### PR DESCRIPTION
Increased `maxPartSize` to 105 MB in the **Move Task**. 

With an AWS imposed maximum of 10,000 parts in a multipart upload, a `maxPartSize` of 105 MB yields a little over 1 TB maximum file size. In order to upload a file of this size, the Pennsieve Agent will require modification to its maximum part size. This can be achieved by setting an environment variable or config file setting.