### PR TITLE
Handle leading path slashes during upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ help:
 	@echo "make publish - package and publish lambda function"
 
 test: clean
-	docker-compose -f docker-compose.test.yml down --remove-orphans
-	docker-compose -f docker-compose.test.yml up --exit-code-from local_tests local_tests
+	docker compose -f docker-compose.test.yml down --remove-orphans
+	docker compose -f docker-compose.test.yml up --build --exit-code-from local_tests local_tests
 
 test-ci:
 	mkdir -p test-dynamodb-data
@@ -46,7 +46,7 @@ go-get:
 
 # Spin down active docker containers.
 docker-clean:
-	docker-compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml down
 
 # Remove dynamodb database
 clean: docker-clean

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,7 @@ services:
       - MANIFEST_FILE_TABLE=manifest-file-table
       - MANIFEST_TABLE=manifest-table
       - IMPORTED_SNS_TOPIC=import-topic
+      #- LOG_LEVEL=DEBUG
     volumes:
       - $PWD:/go/src/github.com/pennsieve/upload-service-v2
       - $PWD/../pennsieve-go-core:/go/src/github.com/pennsieve/pennsieve-go-core

--- a/lambda/upload/go.sum
+++ b/lambda/upload/go.sum
@@ -63,8 +63,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.7.9 h1:FMPo79Cz1ZbvZtAzyOk/XCEI0Hs2F1VHOHaNP3MWWS0=
-github.com/pennsieve/pennsieve-go-core v1.7.9/go.mod h1:LGvjrbDEzDaqWEFB3w8Mf4AzltLyIn1JQShuelOldZ8=
 github.com/pennsieve/pennsieve-go-core v1.9.1 h1:ZtmvsOzDWtE9KKNMYPuc6g2XnMrx2mSRvQPj4ndYbhk=
 github.com/pennsieve/pennsieve-go-core v1.9.1/go.mod h1:Gy4mjXzr//CL99kxmRMH85IT97AH31Ge+hzPc2UEt80=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -82,7 +80,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=

--- a/lambda/upload/handler/changelogger.go
+++ b/lambda/upload/handler/changelogger.go
@@ -1,0 +1,10 @@
+package handler
+
+import (
+	"context"
+	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
+)
+
+type Changelogger interface {
+	EmitEvents(ctx context.Context, params changelog.Message) error
+}

--- a/lambda/upload/handler/dyQueries_test.go
+++ b/lambda/upload/handler/dyQueries_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/uploadFile"
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
 	"github.com/pennsieve/pennsieve-upload-service-v2/upload/test"
-	"github.com/pusher/pusher-http-go/v5"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -31,8 +30,9 @@ func TestDyQueries(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
+			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, mPusher, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/dyQueries_test.go
+++ b/lambda/upload/handler/dyQueries_test.go
@@ -31,7 +31,8 @@ func TestDyQueries(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{})
+			mChangelogger := &test.MockChangelogger{}
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/handler.go
+++ b/lambda/upload/handler/handler.go
@@ -102,7 +102,8 @@ func Handler(ctx context.Context, sqsEvent events.SQSEvent) (events.SQSEventResp
 		ManifestFileTableName,
 		ManifestTableName,
 		SNSTopic,
-		PusherClient)
+		PusherClient,
+		ChangelogClient)
 
 	eventResponse, err = s.Handler(ctx, sqsEvent)
 	if err != nil {

--- a/lambda/upload/handler/handler.go
+++ b/lambda/upload/handler/handler.go
@@ -27,11 +27,12 @@ var (
 	DynamoClient          *dynamodb.Client
 	ManifestTableName     string
 	ManifestFileTableName string
+	JobSQSQueueId         string
 	PusherConfig          *ps.Config
 	PusherClient          *pusher.Client
 )
 
-// init runs on cold start of lambda and gets jwt key-sets from Cognito user pools.
+// init runs on cold start of lambda and configures logging and looks up env vars.
 func init() {
 
 	log.SetFormatter(&log.JSONFormatter{})
@@ -42,6 +43,16 @@ func init() {
 		log.SetLevel(ll)
 	}
 
+	ManifestFileTableName = os.Getenv("MANIFEST_FILE_TABLE")
+	ManifestTableName = os.Getenv("MANIFEST_TABLE")
+	JobSQSQueueId = os.Getenv("JOBS_QUEUE_ID")
+	SNSTopic = os.Getenv("IMPORTED_SNS_TOPIC")
+}
+
+// InitializeClients initializes the clients required by the Handler. Depends on values
+// that are initialized by the package init() function.
+// Separated out from init() since in its current state it really shouldn't be called when tests run
+func InitializeClients() {
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion("us-east-1"))
 	if err != nil {
 		log.Fatalf("LoadDefaultConfig: %v\n", err)
@@ -70,14 +81,11 @@ func init() {
 		}
 	}
 
-	ManifestFileTableName = os.Getenv("MANIFEST_FILE_TABLE")
-	ManifestTableName = os.Getenv("MANIFEST_TABLE")
-	jobSQSQueueId := os.Getenv("JOBS_QUEUE_ID")
 	SNSClient = sns.NewFromConfig(cfg)
 	S3Client = s3.NewFromConfig(cfg)
 	SNSTopic = os.Getenv("IMPORTED_SNS_TOPIC")
 	DynamoClient = dynamodb.NewFromConfig(cfg)
-	ChangelogClient = changelog.NewClient(*sqs.NewFromConfig(cfg), jobSQSQueueId)
+	ChangelogClient = changelog.NewClient(*sqs.NewFromConfig(cfg), JobSQSQueueId)
 }
 
 // Handler implements the function that is called when new SQS Events arrive.

--- a/lambda/upload/handler/handler_test.go
+++ b/lambda/upload/handler/handler_test.go
@@ -257,7 +257,9 @@ func TestMain(m *testing.M) {
 	}
 
 	client := getDynamoDBClient()
-	store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{})
+
+	mChangelogger := &test.MockChangelogger{}
+	store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
 
 	manifestId := "00000000-0000-0000-0000-000000000000"
 	err = populateManifest(store, manifestId, 1)
@@ -295,8 +297,9 @@ func TestUploadService(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			s3Client := test.MockS3{}
+			mChangelogger := &test.MockChangelogger{}
 
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{})
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/handler_test.go
+++ b/lambda/upload/handler/handler_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
 	testHelpers "github.com/pennsieve/pennsieve-go-core/test"
 	"github.com/pennsieve/pennsieve-upload-service-v2/upload/test"
-	"github.com/pusher/pusher-http-go/v5"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"os"
@@ -259,7 +258,8 @@ func TestMain(m *testing.M) {
 	client := getDynamoDBClient()
 
 	mChangelogger := &test.MockChangelogger{}
-	store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
+	mPusher := test.NewMockPusherClient()
+	store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, mPusher, mChangelogger)
 
 	manifestId := "00000000-0000-0000-0000-000000000000"
 	err = populateManifest(store, manifestId, 1)
@@ -297,9 +297,10 @@ func TestUploadService(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			s3Client := test.MockS3{}
+			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}
 
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, s3Client, ManifestFileTableName, ManifestTableName, SNSTopic, mPusher, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/pgQueries_test.go
+++ b/lambda/upload/handler/pgQueries_test.go
@@ -35,7 +35,9 @@ func TestPgQueries(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{})
+			mChangelogger := &test.MockChangelogger{}
+
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/pgQueries_test.go
+++ b/lambda/upload/handler/pgQueries_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
 	testHelpers "github.com/pennsieve/pennsieve-go-core/test"
 	"github.com/pennsieve/pennsieve-upload-service-v2/upload/test"
-	"github.com/pusher/pusher-http-go/v5"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -35,9 +34,10 @@ func TestPgQueries(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
+			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}
 
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, mPusher, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/s3_test.go
+++ b/lambda/upload/handler/s3_test.go
@@ -31,7 +31,9 @@ func TestS3(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{})
+			mChangelogger := &test.MockChangelogger{}
+
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/s3_test.go
+++ b/lambda/upload/handler/s3_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
 	"github.com/pennsieve/pennsieve-upload-service-v2/upload/test"
-	"github.com/pusher/pusher-http-go/v5"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -31,9 +30,10 @@ func TestS3(t *testing.T) {
 
 			mSNS := test.MockSNS{}
 			mS3 := test.MockS3{}
+			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}
 
-			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, &pusher.Client{}, mChangelogger)
+			store := NewUploadHandlerStore(pgdbClient, client, mSNS, mS3, ManifestFileTableName, ManifestTableName, SNSTopic, mPusher, mChangelogger)
 
 			fn(t, store)
 		})

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -137,7 +137,9 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 	})
 
 	// Verify assumptions
-	for _, f := range files {
+	for i, f := range files {
+		// avoiding for-loop variable gotcha
+		files[i].Path = trimSlashes(f.Path)
 		if f.ManifestId != manifest.ManifestId {
 			return errors.New("not all files belong to the same manifest (required for ImportFiles method)")
 		}
@@ -594,7 +596,7 @@ func getUploadFolderMap(sortedFiles []uploadFile.UploadFile, targetFolder string
 
 	// Iterate over the files and create the UploadFolder objects.
 	for _, f := range sortedFiles {
-		p := trimSlashes(f.Path)
+		p := f.Path
 
 		if p == "" {
 			continue
@@ -681,9 +683,8 @@ func getPackageParams(datasetId int, ownerId int, uploadFiles []uploadFile.Uploa
 		}
 
 		parentId := int64(-1)
-		trimmedPath := trimSlashes(file.Path)
-		if trimmedPath != "" {
-			parentId = pathToFolderMap[trimmedPath].Id
+		if file.Path != "" {
+			parentId = pathToFolderMap[file.Path].Id
 		}
 
 		uploadId := sql.NullString{

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -1,6 +1,5 @@
 package handler
 
-import "C"
 import (
 	"context"
 	"database/sql"
@@ -24,7 +23,6 @@ import (
 	ps "github.com/pennsieve/pennsieve-go-core/pkg/models/pusher"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/uploadFile"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/uploadFolder"
-	"github.com/pusher/pusher-http-go/v5"
 	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
@@ -46,10 +44,10 @@ type UploadHandlerStore struct {
 	SNSClient       domain.SnsAPI
 	S3Client        domain.S3API
 	pusherClient    domain.PusherAPI
-	changelogClient Changelogger
 	SNSTopic        string
 	fileTableName   string
 	tableName       string
+	changelogClient Changelogger
 }
 
 type PackagesAndFiles struct {
@@ -65,7 +63,7 @@ type storageUpdateParams struct {
 // NewUploadHandlerStore returns a UploadHandlerStore object which implements the Queries
 func NewUploadHandlerStore(db *sql.DB, dy *dynamodb.Client, sns domain.SnsAPI,
 	s3 domain.S3API, fileTableName string, tableName string, snsTopic string,
-	pc *pusher.Client, changelogger Changelogger) *UploadHandlerStore {
+	pc domain.PusherAPI, changelogger Changelogger) *UploadHandlerStore {
 	return &UploadHandlerStore{
 		pgdb:            db,
 		dynamodb:        dy,

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -71,11 +71,11 @@ func NewUploadHandlerStore(db *sql.DB, dy *dynamodb.Client, sns domain.SnsAPI,
 		SNSClient:       sns,
 		SNSTopic:        snsTopic,
 		S3Client:        s3,
+		changelogClient: changelogger,
 		pg:              NewUploadPgQueries(db),
 		dy:              NewUploadDyQueries(dy),
 		fileTableName:   fileTableName,
 		tableName:       tableName,
-		changelogClient: changelogger,
 	}
 }
 

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -24,7 +24,6 @@ func TestStore(t *testing.T) {
 	){
 		"sorts upload files by path":           testSortFiles,
 		"correctly maps files to folders":      testFolderMapping,
-		"test ignore leading slash":            testRemoveLeadingTrailingSlash,
 		"test folder mapping for nested files": testNestedStructure,
 		"test deleting orphaned files":         testDeleteOrphanedFiles,
 	} {
@@ -169,67 +168,6 @@ func testFolderMapping(t *testing.T, _ *UploadHandlerStore) {
 	// Check folder depth
 	assert.Equal(t, 2, folderMap2["hello/you/folder1"].Depth)
 	assert.Equal(t, 4, folderMap2["hello/you/folder1/folder2/folder3"].Depth)
-
-}
-
-func testRemoveLeadingTrailingSlash(t *testing.T, _ *UploadHandlerStore) {
-	uploadFile1 := uploadFile.UploadFile{
-		ManifestId: "",
-		Path:       "/folder1/folder2",
-		Name:       "",
-		Extension:  "",
-		Type:       0,
-		SubType:    "",
-		Icon:       0,
-		Size:       0,
-		ETag:       "",
-	}
-	uploadFile2 := uploadFile.UploadFile{
-		ManifestId: "",
-		Path:       "/////folder1/folder10",
-		Name:       "",
-		Extension:  "",
-		Type:       0,
-		SubType:    "",
-		Icon:       0,
-		Size:       0,
-		ETag:       "",
-	}
-	uploadFile3 := uploadFile.UploadFile{
-		ManifestId: "",
-		Path:       "/folder1/folder10///",
-		Name:       "",
-		Extension:  "",
-		Type:       0,
-		SubType:    "",
-		Icon:       0,
-		Size:       0,
-		ETag:       "",
-	}
-	uploadFile4 := uploadFile.UploadFile{
-		ManifestId: "",
-		Path:       "/folder1/folder10/",
-		Name:       "",
-		Extension:  "",
-		Type:       0,
-		SubType:    "",
-		Icon:       0,
-		Size:       0,
-		ETag:       "",
-	}
-
-	uploadFiles := []uploadFile.UploadFile{
-		uploadFile1,
-		uploadFile2,
-		uploadFile3,
-		uploadFile4,
-	}
-
-	folderMap := getUploadFolderMap(uploadFiles, "")
-
-	t.Log(folderMap)
-	// Number of folders
-	assert.Equal(t, 3, len(folderMap))
 
 }
 

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -368,8 +368,12 @@ func testImportFilesSingleFile(t *testing.T, orgID int, store *UploadHandlerStor
 	}
 
 	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
-		test.AssertRowCount(t, store.pgdb, orgID, "packages", 1)
-		test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": files[0].Name})
+		}
+		if test.AssertRowCount(t, store.pgdb, orgID, "files", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "files", map[string]any{"name": files[0].Name})
+		}
 	}
 
 }
@@ -418,8 +422,13 @@ func testImportFilesSingleFileInFolder(t *testing.T, orgID int, store *UploadHan
 
 	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
 		// One package for the folder and one for the file
-		test.AssertRowCount(t, store.pgdb, orgID, "packages", 2)
-		test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 2) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "dir1"})
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "file1.txt"})
+		}
+		if test.AssertRowCount(t, store.pgdb, orgID, "files", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "files", map[string]any{"name": "file1.txt"})
+		}
 	}
 
 }
@@ -468,8 +477,12 @@ func testImportFilesSingleWithLeadingSlash(t *testing.T, orgID int, store *Uploa
 
 	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
 		// There should only be one package since the path is "/", the import should not create a containing folder.
-		test.AssertRowCount(t, store.pgdb, orgID, "packages", 1)
-		test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "file1.txt"})
+		}
+		if test.AssertRowCount(t, store.pgdb, orgID, "files", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "files", map[string]any{"name": "file1.txt"})
+		}
 	}
 
 }
@@ -518,8 +531,13 @@ func testImportFilesSingleInFolderWithLeadingSlash(t *testing.T, orgID int, stor
 
 	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
 		// Two packages: dir1 and file1.txt
-		test.AssertRowCount(t, store.pgdb, orgID, "packages", 2)
-		test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 2) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "dir1"})
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "file1.txt"})
+		}
+		if test.AssertRowCount(t, store.pgdb, orgID, "files", 1) {
+			test.AssertExistsOneWhere(t, store.pgdb, orgID, "files", map[string]any{"name": "file1.txt"})
+		}
 	}
 
 }

--- a/lambda/upload/main.go
+++ b/lambda/upload/main.go
@@ -5,6 +5,9 @@ import (
 	"github.com/pennsieve/pennsieve-upload-service-v2/upload/handler"
 )
 
+func init() {
+	handler.InitializeClients()
+}
 func main() {
 	lambda.Start(handler.Handler)
 }

--- a/lambda/upload/test/pgtest.go
+++ b/lambda/upload/test/pgtest.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func AssertRowCount(t *testing.T, db *sql.DB, orgID int, table string, expectedRowCount int) bool {
+
+	qualifiedTable := fmt.Sprintf(`"%d".%s`, orgID, table)
+	query := fmt.Sprintf(`SELECT COUNT(*) FROM %s`, qualifiedTable)
+
+	row := db.QueryRow(query)
+	var count int
+	err := row.Scan(&count)
+	if assert.NoError(t, err) {
+		return assert.Equal(t, expectedRowCount, count, "expected table %s to have %d rows, found %d instead",
+			qualifiedTable, expectedRowCount, count)
+	}
+	return false
+}

--- a/lambda/upload/test/pgtest.go
+++ b/lambda/upload/test/pgtest.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +19,29 @@ func AssertRowCount(t *testing.T, db *sql.DB, orgID int, table string, expectedR
 	if assert.NoError(t, err) {
 		return assert.Equal(t, expectedRowCount, count, "expected table %s to have %d rows, found %d instead",
 			qualifiedTable, expectedRowCount, count)
+	}
+	return false
+}
+
+func AssertExistsOneWhere(t *testing.T, db *sql.DB, orgID int, table string, where map[string]any) bool {
+	qualifiedTable := fmt.Sprintf(`"%d".%s`, orgID, table)
+	var conditions []string
+	var args []any
+	i := 1
+	for columnName, value := range where {
+		conditions = append(conditions, fmt.Sprintf("%s = $%d", columnName, i))
+		i++
+		args = append(args, value)
+	}
+	whereClause := strings.Join(conditions, " AND ")
+	query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s`, qualifiedTable, whereClause)
+
+	row := db.QueryRow(query, args...)
+	var count int
+	err := row.Scan(&count)
+	if assert.NoError(t, err) {
+		return assert.Equal(t, 1, count, "expected table %s to have one match for %s, found %d instead",
+			qualifiedTable, where, count)
 	}
 	return false
 }

--- a/lambda/upload/test/pgtest.go
+++ b/lambda/upload/test/pgtest.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"strings"
@@ -29,9 +30,16 @@ func AssertExistsOneWhere(t *testing.T, db *sql.DB, orgID int, table string, whe
 	var args []any
 	i := 1
 	for columnName, value := range where {
-		conditions = append(conditions, fmt.Sprintf("%s = $%d", columnName, i))
-		i++
-		args = append(args, value)
+		var condition string
+		if value == nil {
+			condition = fmt.Sprintf("%s IS NULL", columnName)
+		} else {
+			condition = fmt.Sprintf("%s = $%d", columnName, i)
+			i++
+			args = append(args, value)
+
+		}
+		conditions = append(conditions, condition)
 	}
 	whereClause := strings.Join(conditions, " AND ")
 	query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s`, qualifiedTable, whereClause)
@@ -42,6 +50,30 @@ func AssertExistsOneWhere(t *testing.T, db *sql.DB, orgID int, table string, whe
 	if assert.NoError(t, err) {
 		return assert.Equal(t, 1, count, "expected table %s to have one match for %s, found %d instead",
 			qualifiedTable, where, count)
+	}
+	return false
+}
+
+// AssertPackageIsChild compares packages based on name for convenience but this means it may not work if there are multiple
+// packages with the same name
+func AssertPackageIsChild(t *testing.T, db *sql.DB, orgID int, childName string, expectedParentName string) bool {
+
+	qualifiedTable := fmt.Sprintf(`"%d".%s`, orgID, "packages")
+	query := fmt.Sprintf(`SELECT TRUE FROM %s child JOIN %s parent ON child.parent_id = parent.id
+                                         WHERE child.name = '%s' AND parent.name = '%s'`,
+		qualifiedTable,
+		qualifiedTable,
+		childName,
+		expectedParentName)
+
+	row := db.QueryRow(query)
+	var isChild bool
+	if err := row.Scan(&isChild); errors.Is(err, sql.ErrNoRows) {
+		return assert.Fail(t, "package is not child of expected parent", "expected package %s to be child of %s in table %s",
+			childName, expectedParentName, qualifiedTable)
+	} else if assert.NoError(t, err) {
+		return assert.True(t, isChild, "expected package %s to be child of %s in table %s",
+			childName, expectedParentName, qualifiedTable)
 	}
 	return false
 }

--- a/lambda/upload/test/test.go
+++ b/lambda/upload/test/test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
+	"github.com/pusher/pusher-http-go/v5"
 )
 
 type MockSNS struct{}
@@ -54,4 +55,42 @@ type MockChangelogger struct {
 func (m *MockChangelogger) EmitEvents(ctx context.Context, params changelog.Message) error {
 	m.Messages = append(m.Messages, params)
 	return nil
+}
+
+func (m *MockChangelogger) Clear() {
+	m.Messages = nil
+}
+
+type MockPusherClient struct {
+	// Triggered maps channel -> eventName -> []data
+	Triggered map[string]map[string][]any
+}
+
+func NewMockPusherClient() *MockPusherClient {
+	return &MockPusherClient{Triggered: map[string]map[string][]any{}}
+}
+
+func (m *MockPusherClient) captureEvent(channel string, eventName string, data any) {
+	if eventMap, ok := m.Triggered[channel]; ok {
+		eventMap[eventName] = append(eventMap[eventName], data)
+		m.Triggered[channel] = eventMap
+	} else {
+		m.Triggered[channel] = map[string][]any{eventName: {data}}
+	}
+}
+
+func (m *MockPusherClient) TriggerBatch(batch []pusher.Event) (*pusher.TriggerBatchChannelsList, error) {
+	for _, event := range batch {
+		m.captureEvent(event.Channel, event.Name, event.Data)
+	}
+	// TODO a more realistic return value
+	return &pusher.TriggerBatchChannelsList{}, nil
+}
+
+func (m *MockPusherClient) Trigger(channel string, eventName string, data interface{}) error {
+	m.captureEvent(channel, eventName, data)
+	return nil
+}
+func (m *MockPusherClient) Clear() {
+	m.Triggered = map[string]map[string][]any{}
 }

--- a/lambda/upload/test/test.go
+++ b/lambda/upload/test/test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/smithy-go/middleware"
+	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
 )
 
 type MockSNS struct{}
@@ -44,4 +45,13 @@ func (s MockS3) DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInput
 		Deleted: deleted,
 	}
 	return &result, nil
+}
+
+type MockChangelogger struct {
+	Messages []changelog.Message
+}
+
+func (m *MockChangelogger) EmitEvents(ctx context.Context, params changelog.Message) error {
+	m.Messages = append(m.Messages, params)
+	return nil
 }


### PR DESCRIPTION
PR fixes an issue when a user creates an upload manifest where the target paths contain leading slashes.

Leading slashes were being removed in one place but not another. This PR moves the slash trimming to the top of `ImportFiles` so that it only has to happen once.

Adds test cases for this case as well as the more usual case of no leading slashes. Removed some existing tests that were made obsolete by the change in where slash trimming happens.

Includes a little refactoring of `UploadHandlerStore` for testability.

Ideally the trimming would happen in the `Handler` method rather than `ImportFiles` but `Handler` is harder to write tests for since it would require setting up contents for DynamoDB calls.

Ticket: https://app.clickup.com/t/86891cnr0