### PR TITLE
Fix GetUploadFiles() handling of unprocessed keys

### DIFF
--- a/lambda/upload/handler/dyQueries.go
+++ b/lambda/upload/handler/dyQueries.go
@@ -88,13 +88,15 @@ func (q *UploadDyQueries) GetUploadFiles(entries []UploadEntry) ([]uploadFile.Up
 
 		// Re-request missing items if for some reason dynamodb does not return all events
 		for len(dbResults.UnprocessedKeys) > 0 {
-			moreResults, err := q.db.BatchGetItem(context.Background(), &batchItemInput)
+			dbResults, err = q.db.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+				RequestItems: dbResults.UnprocessedKeys,
+			})
 			if err != nil {
 				log.Error(fmt.Sprintf("Unable to get dbItems: %v", err))
 				return nil, nil, err
 			}
 
-			dbItems = append(dbItems, moreResults.Responses[ManifestFileTableName]...)
+			dbItems = append(dbItems, dbResults.Responses[ManifestFileTableName]...)
 		}
 
 		for _, dbItem := range dbItems {

--- a/lambda/upload/test/test.go
+++ b/lambda/upload/test/test.go
@@ -3,12 +3,15 @@ package test
 import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
 	"github.com/pusher/pusher-http-go/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockSNS struct{}
@@ -93,4 +96,54 @@ func (m *MockPusherClient) Trigger(channel string, eventName string, data interf
 }
 func (m *MockPusherClient) Clear() {
 	m.Triggered = map[string]map[string][]any{}
+}
+
+type MockDynamoDB struct {
+	TestingT              require.TestingT
+	BatchGetItemOutputs   []*dynamodb.BatchGetItemOutput
+	BatchGetItemCallCount int
+}
+
+func (m *MockDynamoDB) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.GetItem if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.Query if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.UpdateItem if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.BatchWriteItem if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.PutItem if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) BatchGetItem(ctx context.Context, params *dynamodb.BatchGetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
+	if m.BatchGetItemCallCount < len(m.BatchGetItemOutputs) {
+		output := m.BatchGetItemOutputs[m.BatchGetItemCallCount]
+		m.BatchGetItemCallCount++
+		return output, nil
+	}
+	require.FailNow(m.TestingT, "unexpected number of calls to BatchGetItem", "expected %d calls, got %d calls", len(m.BatchGetItemOutputs), m.BatchGetItemCallCount+1)
+	return nil, nil
+}
+
+func (m *MockDynamoDB) BatchExecuteStatement(ctx context.Context, params *dynamodb.BatchExecuteStatementInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchExecuteStatementOutput, error) {
+	require.FailNow(m.TestingT, "mock method has not been implemented; implement test.MockDynamoDB.BatchExecuteStatement if this is an expected call")
+	return nil, nil
+}
+
+func (m *MockDynamoDB) AssertBatchGetItemCallCount(expectedCallCount int) bool {
+	return assert.Equal(m.TestingT, expectedCallCount, m.BatchGetItemCallCount)
 }


### PR DESCRIPTION
Fix `UploadDyQueries.GetUploadFiles()` use of DynamoDB `BatchGetItem()` to avoid an infinite loop if the response contains a non-empty `UnprocessedKeys` field.

Adds a mock `dydb.DB` and a test for this case.

Ticket: https://app.clickup.com/t/86862p6y0