### PR TITLE
Add toolchain go1.23.4

### DIFF
--- a/lambda/moveTrigger/go.mod
+++ b/lambda/moveTrigger/go.mod
@@ -2,6 +2,8 @@ module github.com/pennsieve/pennsieve-upload-service-v2/move-trigger
 
 go 1.22
 
+toolchain go1.23.4
+
 require (
 	github.com/aws/aws-lambda-go v1.32.0
 	github.com/aws/aws-sdk-go-v2 v1.16.5

--- a/lambda/upload/go.mod
+++ b/lambda/upload/go.mod
@@ -2,6 +2,8 @@ module github.com/pennsieve/pennsieve-upload-service-v2/upload
 
 go 1.22
 
+toolchain go1.23.4
+
 //
 //replace github.com/pennsieve/pennsieve-go-core => ../../../pennsieve-go-core
 


### PR DESCRIPTION
Some Lambda builds succeed on Jenkins and some fail. The ones that succeed have `toolchain` specified in their go.mod files.