### PR TITLE
Fix uploads bucket lifecycle rules

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -27,9 +27,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "upload_s3_bucket_lifecycle" {
       days_after_initiation = 7
     }
 
-    expiration {
-      days = 7
-    }
     status = "Enabled"
   }
 }


### PR DESCRIPTION
The uploads bucket should not be deleting objects seven days after creation. 

PR removes this rule from Terraform, leaving the incomplete multipart upload rule in place.