### PR TITLE
updated batch size and concurancy

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "upload_lambda" {
   memory_size      = 128
   s3_bucket         = var.lambda_bucket
   s3_key            = "${var.service_name}/upload/upload-v2-handler-${var.image_tag}.zip"
+  reserved_concurrent_executions = 100 // Set a maximum concurrency to prevent overloading RDS interaction
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
@@ -98,7 +99,6 @@ resource "aws_lambda_function" "archive_lambda" {
 
 
 ### MOVE TRIGGER
-
 resource "aws_lambda_function" "fargate_trigger_lambda" {
   description      = "Lambda Function which triggers FARGATE to move files to final destination."
   function_name    = "${var.environment_name}-${var.service_name}-fargate-trigger-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -22,7 +22,7 @@ resource "aws_sqs_queue" "upload_trigger_deadletter_queue" {
 resource "aws_lambda_event_source_mapping" "upload_source_mapping" {
   event_source_arn = aws_sqs_queue.upload_trigger_queue.arn
   function_name    = aws_lambda_function.upload_lambda.arn
-  batch_size = 25
+  batch_size = 500
   maximum_batching_window_in_seconds = 5
   function_response_types = ["ReportBatchItemFailures"]
 }
@@ -91,8 +91,8 @@ resource "aws_sqs_queue" "imported_file_deadletter_queue" {
 resource "aws_lambda_event_source_mapping" "imported_file_mapping" {
   event_source_arn = aws_sqs_queue.imported_file_queue.arn
   function_name    = aws_lambda_function.fargate_trigger_lambda.function_name
-  batch_size = 25
-  maximum_batching_window_in_seconds = 300
+  batch_size = 1000
+  maximum_batching_window_in_seconds = 30
 }
 
 # Grant SNS to post to SQS queue


### PR DESCRIPTION
Updated Batch size in SQS queue and concurrency for upload lambda to prevent blocking and timing out during high loads.