### PR TITLE
Update Go Lambda runtimes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/fargate/upload-move; \
-		env GOOS=linux GOARCH=amd64 go build -o app/upload-move-files; \
+#		env GOOS=linux GOARCH=amd64 go build -o app/upload-move-files; \
 		docker build -t pennsieve/upload_move_files:${VERSION} . ;\
 		docker push pennsieve/upload_move_files:${VERSION} ;\
 

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ test-ci:
 	chmod -R 777 test-dynamodb-data
 	mkdir -p testdata
 	chmod -R 777 testdata
-	docker-compose -f docker-compose.test.yml down --remove-orphans
-	docker-compose -f docker-compose.test.yml up --exit-code-from ci_tests ci_tests
+	docker compose -f docker-compose.test.yml down --remove-orphans
+	docker compose -f docker-compose.test.yml up --exit-code-from ci_tests ci_tests
 
 go-get:
 	cd $(WORKING_DIR)/lambda/service; \
@@ -52,6 +52,8 @@ docker-clean:
 clean: docker-clean
 	rm -rf test-dynamodb-data
 	rm -rf testdata
+	rm -rf lambda/bin
+	rm -rf miniodata
 
 package:
 	@echo ""
@@ -60,7 +62,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/lambda/service; \
-  		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/service/pennsieve_upload_service; \
+  		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/service/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/service/$(SERVICE_PACKAGE_NAME) .
 	@echo ""
@@ -69,7 +71,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/lambda/upload; \
-		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/upload/pennsieve_upload_handler; \
+		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/upload/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/upload/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/upload/$(UPLOADHANDLER_PACKAGE_NAME) .
 	@echo ""
@@ -78,7 +80,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/lambda/moveTrigger; \
-  		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/moveTrigger/pennsieve_move_trigger; \
+  		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/moveTrigger/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/moveTrigger/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/moveTrigger/$(MOVETRIGGER_PACKAGE_NAME) .
 	@echo ""
@@ -87,7 +89,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/lambda/archiver; \
-  		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/archiver/manifest_archiver; \
+  		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/archiver/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/archiver/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/archiver/$(ARCHIVER_PACKAGE_NAME) .
 	@echo ""
@@ -96,7 +98,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/fargate/upload-move; \
-#		env GOOS=linux GOARCH=amd64 go build -o app/upload-move-files; \
+		env GOOS=linux GOARCH=amd64 go build -o app/upload-move-files; \
 		docker build -t pennsieve/upload_move_files:${VERSION} . ;\
 		docker push pennsieve/upload_move_files:${VERSION} ;\
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -2,8 +2,9 @@
 resource "aws_lambda_function" "upload_lambda" {
   description      = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
   function_name    = "${var.environment_name}-${var.service_name}-upload-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "pennsieve_upload_handler"
-  runtime          = "go1.x"
+  handler          = "bootstrap"
+  runtime          = "provided.al2023"
+  architectures    = ["arm64"]
   role             = aws_iam_role.upload_service_v2_lambda_role.arn
   timeout          = 300
   memory_size      = 128
@@ -37,8 +38,9 @@ resource "aws_lambda_function" "upload_lambda" {
 resource "aws_lambda_function" "service_lambda" {
   description      = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
   function_name    = "${var.environment_name}-${var.service_name}-service-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "pennsieve_upload_service"
-  runtime          = "go1.x"
+  handler          = "bootstrap"
+  runtime          = "provided.al2023"
+  architectures    = ["arm64"]
   role             = aws_iam_role.upload_service_v2_lambda_role.arn
   timeout          = 300
   memory_size      = 128
@@ -70,8 +72,9 @@ resource "aws_lambda_function" "service_lambda" {
 resource "aws_lambda_function" "archive_lambda" {
   description      = "Lambda Function which archives a manifest when triggered by the service."
   function_name    = "${var.environment_name}-${var.service_name}-archive-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "manifest_archiver"
-  runtime          = "go1.x"
+  handler          = "bootstrap"
+  runtime          = "provided.al2023"
+  architectures    = ["arm64"]
   role             = aws_iam_role.upload_service_v2_lambda_role.arn
   timeout          = 600
   memory_size      = 128
@@ -103,8 +106,9 @@ resource "aws_lambda_function" "fargate_trigger_lambda" {
   description      = "Lambda Function which triggers FARGATE to move files to final destination."
   function_name    = "${var.environment_name}-${var.service_name}-fargate-trigger-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   reserved_concurrent_executions = 1 // don't allow concurrent lambda's
-  handler          = "pennsieve_move_trigger"
-  runtime          = "go1.x"
+  handler          = "bootstrap"
+  runtime          = "provided.al2023"
+  architectures    = ["arm64"]
   role             = aws_iam_role.move_trigger_lambda_role.arn
   timeout          = 300
   memory_size      = 128

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -23,6 +23,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "upload_s3_bucket_lifecycle" {
   rule {
     id = "expire-partial-uploads"
 
+    filter {}
+
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
     }

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -22,7 +22,7 @@ resource "aws_sqs_queue" "upload_trigger_deadletter_queue" {
 resource "aws_lambda_event_source_mapping" "upload_source_mapping" {
   event_source_arn = aws_sqs_queue.upload_trigger_queue.arn
   function_name    = aws_lambda_function.upload_lambda.arn
-  batch_size = 500
+  batch_size = 25
   maximum_batching_window_in_seconds = 5
   function_response_types = ["ReportBatchItemFailures"]
 }
@@ -91,8 +91,8 @@ resource "aws_sqs_queue" "imported_file_deadletter_queue" {
 resource "aws_lambda_event_source_mapping" "imported_file_mapping" {
   event_source_arn = aws_sqs_queue.imported_file_queue.arn
   function_name    = aws_lambda_function.fargate_trigger_lambda.function_name
-  batch_size = 1000
-  maximum_batching_window_in_seconds = 30
+  batch_size = 25
+  maximum_batching_window_in_seconds = 300
 }
 
 # Grant SNS to post to SQS queue


### PR DESCRIPTION
Updates the Go Lambda runtimes from go1.x to provided.al2023. 

This requires a newer version of the Terraform AWS provider, which is done in https://github.com/Pennsieve/infrastructure/pull/337. This newer version did not like a `aws_s3_bucket_lifecycle_configuration` resource block with no filter or prefix, so PR also adds an empty filter to that resource block.