### PR TITLE
Add dynamic storage node IAM policies

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -122,3 +122,14 @@ data "terraform_remote_state" "api_gateway" {
     profile = var.aws_account
   }
 }
+# Import Account Service (storage node policies)
+data "terraform_remote_state" "account_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/account-service/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -861,3 +861,8 @@ data "aws_iam_policy_document" "cognito_upload_unauth_identity_policy_document" 
   }
 }
 
+
+resource "aws_iam_role_policy_attachment" "fargate_storage_bucket_write" {
+  role       = aws_iam_role.fargate_task_iam_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_write_policy_arn
+}


### PR DESCRIPTION
## Summary
- Import account-service terraform remote state
- Attach managed `storage_bucket_write` policy to `fargate_task_iam_role`
- Write access needed: Fargate move task copies files from upload bucket into org storage buckets

## Context
Part of the distributed storage nodes feature. The account-service maintains dynamically-updated IAM policies that are auto-updated when storage nodes are created/modified/deleted.

## Test plan
- [ ] Terraform plan shows only new policy attachment resources
- [ ] No changes to existing IAM policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)