### PR TITLE
Add direct-to-storage upload path with two-phase finalize

### DIFF
--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -7,7 +7,7 @@ go 1.24.0
 //)
 require (
 	github.com/aws/aws-lambda-go v1.46.0
-	github.com/aws/aws-sdk-go-v2 v1.41.3
+	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.7
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.9
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.30.4
@@ -29,6 +29,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.3 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -1,7 +1,10 @@
 github.com/aws/aws-lambda-go v1.46.0 h1:UWVnvh2h2gecOlFhHQfIPQcD8pL/f7pVCutmFl+oXU8=
 github.com/aws/aws-lambda-go v1.46.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/aws/aws-sdk-go-v2 v1.17.5/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
 github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
+github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 h1:gTK2uhtAPtFcdRRJilZPx8uJLL2J85xK11nKtWL0wfU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1/go.mod h1:sxpLb+nZk7tIfCWChfd+h4QwHNUR57d8hA1cleTkjJo=
 github.com/aws/aws-sdk-go-v2/config v1.27.7 h1:JSfb5nOQF01iOgxFI5OIKWwDiEXWTyTgg1Mm1mHi0A4=
@@ -12,6 +15,10 @@ github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.9 h1:wcPuFDEP
 github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.9/go.mod h1:KS9rl02fOHtG8eOcCvA0jFT30aUIoVs5tcq7lsSmJT0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.3 h1:p+y7FvkK2dxS+FEwRIDHDe//ZX+jDhP8HHE50ppj4iI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.3/go.mod h1:/fYB+FZbDlwlAiynK9KDXlzZl3ANI9JkD0Uhz5FjNT4=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 h1:xTuoSBz6RDIzDb8kqveEdpYUmgksxYNFeNKSYUATM4s=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7/go.mod h1:x9SeCjHqRHARRCh05Krdd3Ywmqf6cd9BtHAPN/2VYo0=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 h1:HFn8sVT87KWnGs2Q2gO/brPZc2bR0RXD++cYKRmABzk=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21/go.mod h1:BGZ/K6gLGJt8K36j6gcsD7WVxmWt0MGBYtr57iLweio=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 h1:/sECfyq2JTifMI2JPyZ4bdRN77zJmr6SrS1eL3augIA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19/go.mod h1:dMf8A5oAqr9/oxOfLkC/c2LU/uMcALP0Rgn2BD5LWn0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 h1:AWeJMk33GTBf6J20XJe6qZoRSJo0WfUhsMdUKhoODXE=
@@ -44,6 +51,7 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.2 h1:pi0Skl6mNl2w8qWZXcdOyg19
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.2/go.mod h1:JYzLoEVeLXk+L4tn1+rrkfhkxl6mLDEVaDSvGq9og90=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.8 h1:XQTQTF75vnug2TXS8m7CVJfC2nniYPZnO1D4Np761Oo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.8/go.mod h1:Xgx+PR1NUOjNmQY+tRMnouRp83JRM8pRMw/vCaVhPkI=
+github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -52,6 +60,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/lambda/service/handler/finalize_files.go
+++ b/lambda/service/handler/finalize_files.go
@@ -1,0 +1,376 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dyTypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdaTypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/gateway"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
+	pgQueries "github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
+	dyQueriesNs "github.com/pennsieve/pennsieve-go-core/pkg/queries/dydb"
+	"github.com/pennsieve/pennsieve-upload-service-v2/service/pkg/storage"
+	log "github.com/sirupsen/logrus"
+)
+
+// maxFinalizeBatch bounds a single finalize request. Aligns with the agent's
+// dispatch batch size and keeps handler runtime predictable.
+const maxFinalizeBatch = 500
+
+// headConcurrency caps how many HeadObject calls run in parallel per invocation.
+const headConcurrency = 50
+
+type finalizeFileRequest struct {
+	UploadID string `json:"uploadId"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256,omitempty"`
+}
+
+type finalizeRequest struct {
+	ManifestNodeID string                `json:"manifestNodeId"`
+	Files          []finalizeFileRequest `json:"files"`
+}
+
+type finalizeResult struct {
+	UploadID string `json:"uploadId"`
+	Status   string `json:"status"` // "finalized" | "failed"
+	Error    string `json:"error,omitempty"`
+}
+
+type finalizeResponse struct {
+	Results []finalizeResult `json:"results"`
+}
+
+// postFinalizeFilesRoute is the two-phase upload completion endpoint. The
+// agent calls this after it has successfully PUT each file directly to the
+// storage bucket; we verify, import into Postgres, and mark the manifest file
+// Finalized. Idempotent per uploadId.
+func postFinalizeFilesRoute(request events.APIGatewayV2HTTPRequest, claims *authorizer.Claims) (*events.APIGatewayV2HTTPResponse, error) {
+	var req finalizeRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil {
+		log.WithError(err).Warn("finalize: invalid request body")
+		return errResp(400, "invalid request body")
+	}
+	if !isValidUUID(req.ManifestNodeID) {
+		return errResp(400, "manifestNodeId must be a UUID")
+	}
+	if len(req.Files) == 0 {
+		return errResp(400, "files is required and must be non-empty")
+	}
+	if len(req.Files) > maxFinalizeBatch {
+		return errResp(400, fmt.Sprintf("batch_too_large: max %d files per request", maxFinalizeBatch))
+	}
+	// Per-file input validation. Bad inputs fail the whole batch — we don't
+	// want to quietly drop malformed entries because the client may think they
+	// were accepted.
+	for i, f := range req.Files {
+		if !isValidUUID(f.UploadID) {
+			return errResp(400, fmt.Sprintf("files[%d].uploadId must be a UUID", i))
+		}
+		if f.Size <= 0 {
+			return errResp(400, fmt.Sprintf("files[%d].size must be > 0", i))
+		}
+		if f.SHA256 == "" {
+			return errResp(400, fmt.Sprintf("files[%d].sha256 is required", i))
+		}
+	}
+
+	ctx := context.Background()
+
+	// Auth: manifest must belong to the caller's dataset.
+	manifestRecord, err := store.dy.GetManifestById(ctx, store.tableName, req.ManifestNodeID)
+	if err != nil {
+		log.WithError(err).WithField("manifestNodeId", req.ManifestNodeID).Warn("manifest not found")
+		return errResp(404, "Manifest not found")
+	}
+	if manifestRecord.DatasetNodeId != claims.DatasetClaim.NodeId {
+		return errResp(403, "Manifest does not belong to this dataset")
+	}
+
+	defaultStorageBucket := os.Getenv("DEFAULT_STORAGE_BUCKET")
+	if defaultStorageBucket == "" {
+		log.Error("DEFAULT_STORAGE_BUCKET not configured")
+		return errResp(500, "Storage not configured")
+	}
+	uploadLambdaArn := os.Getenv("UPLOAD_LAMBDA_ARN")
+	if uploadLambdaArn == "" {
+		log.Error("UPLOAD_LAMBDA_ARN not configured")
+		return errResp(500, "Finalize dispatch not configured")
+	}
+
+	// Resolve destination bucket (same resolver the storage-credentials endpoint uses).
+	pgdb, err := pgQueries.ConnectRDS()
+	if err != nil {
+		log.WithError(err).Error("failed to connect to RDS")
+		return errResp(500, "Internal error")
+	}
+	defer pgdb.Close()
+
+	resolution, err := storage.ResolveForManifest(
+		ctx,
+		req.ManifestNodeID,
+		store.tableName,
+		defaultStorageBucket,
+		dyQueriesNs.New(store.dynamodb),
+		pgQueries.New(pgdb),
+	)
+	if err != nil {
+		log.WithError(err).WithField("manifestNodeId", req.ManifestNodeID).Error("failed to resolve storage bucket")
+		return errResp(500, "Failed to resolve storage bucket")
+	}
+	keyPrefix := resolution.KeyPrefix(req.ManifestNodeID)
+
+	// Look up all files' current status in one BatchGetItem. The result map
+	// serves two purposes:
+	//   1. idempotency — skip files already in Finalized status
+	//   2. auth/ownership — uploadIds not present in the manifest's
+	//      manifest_files rows are rejected outright (prevents a caller from
+	//      submitting arbitrary uploadIds and triggering orphan-file deletion
+	//      in the upload lambda downstream)
+	manifestFileStatus, err := fetchManifestFileStatuses(ctx, store.dynamodb, store.fileTableName, req.ManifestNodeID, req.Files)
+	if err != nil {
+		log.WithError(err).WithField("manifestNodeId", req.ManifestNodeID).Error("finalize: failed to load manifest file statuses")
+		return errResp(500, "internal error")
+	}
+
+	// Parallel HEAD verification on the storage bucket.
+	resultsByUploadID := make(map[string]finalizeResult, len(req.Files))
+	toImport := make([]finalizeFileRequest, 0, len(req.Files))
+	var mu sync.Mutex
+	sem := make(chan struct{}, headConcurrency)
+	var wg sync.WaitGroup
+
+	for _, f := range req.Files {
+		status, inManifest := manifestFileStatus[f.UploadID]
+		if !inManifest {
+			resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "uploadId not found in manifest"}
+			continue
+		}
+		if status == manifestFile.Finalized.String() {
+			resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "finalized"}
+			continue
+		}
+
+		wg.Add(1)
+		f := f
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			key := fmt.Sprintf("%s/%s", keyPrefix, f.UploadID)
+			head, err := store.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+				Bucket: aws.String(resolution.StorageBucket),
+				Key:    aws.String(key),
+			})
+			if err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"manifest_id": req.ManifestNodeID,
+					"upload_id":   f.UploadID,
+				}).Warn("finalize: HEAD failed")
+				mu.Lock()
+				resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "object not found"}
+				mu.Unlock()
+				return
+			}
+			if head.ContentLength != nil && *head.ContentLength != f.Size {
+				mu.Lock()
+				resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "size mismatch"}
+				mu.Unlock()
+				return
+			}
+			// SHA256 is required (validated upstream). Enforce match against
+			// what S3 computed & stored during the multipart upload.
+			if head.ChecksumSHA256 == nil || *head.ChecksumSHA256 != f.SHA256 {
+				mu.Lock()
+				resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "sha256 mismatch"}
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			toImport = append(toImport, f)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Synthesize S3 events for the verified files and invoke the upload
+	// lambda synchronously. The upload lambda recognizes the O-prefixed key
+	// as direct-to-storage, creates Postgres rows, and marks Finalized.
+	if len(toImport) > 0 {
+		failed, err := dispatchToUploadLambda(ctx, store.lambdaClient, uploadLambdaArn, resolution.StorageBucket, keyPrefix, toImport)
+		if err != nil {
+			// Whole-batch failure — mark all toImport as failed.
+			log.WithError(err).Error("failed to dispatch to upload lambda")
+			for _, f := range toImport {
+				resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "import dispatch failed"}
+			}
+		} else {
+			for _, f := range toImport {
+				if _, bad := failed[f.UploadID]; bad {
+					resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "import failed"}
+				} else {
+					resultsByUploadID[f.UploadID] = finalizeResult{UploadID: f.UploadID, Status: "finalized"}
+				}
+			}
+		}
+	}
+
+	// Preserve input order in the response.
+	results := make([]finalizeResult, 0, len(req.Files))
+	for _, f := range req.Files {
+		if r, ok := resultsByUploadID[f.UploadID]; ok {
+			results = append(results, r)
+		} else {
+			results = append(results, finalizeResult{UploadID: f.UploadID, Status: "failed", Error: "unknown"})
+		}
+	}
+
+	body, _ := json.Marshal(finalizeResponse{Results: results})
+	return &events.APIGatewayV2HTTPResponse{StatusCode: 200, Body: string(body)}, nil
+}
+
+func errResp(code int, msg string) (*events.APIGatewayV2HTTPResponse, error) {
+	return &events.APIGatewayV2HTTPResponse{
+		StatusCode: code,
+		Body:       gateway.CreateErrorMessage(msg, code),
+	}, nil
+}
+
+// fetchManifestFileStatuses returns a map from uploadId to current Status for
+// every requested uploadId that exists in the manifest's manifest_files rows.
+// UploadIds not in the result map are not part of the manifest and must be
+// rejected by the caller (prevents callers from submitting arbitrary
+// uploadIds and triggering orphan-file deletion downstream).
+func fetchManifestFileStatuses(
+	ctx context.Context,
+	dy *dynamodb.Client,
+	fileTable string,
+	manifestId string,
+	files []finalizeFileRequest,
+) (map[string]string, error) {
+	if len(files) == 0 {
+		return map[string]string{}, nil
+	}
+
+	// BatchGetItem caps at 100 items per request.
+	statuses := make(map[string]string, len(files))
+	for start := 0; start < len(files); start += 100 {
+		end := start + 100
+		if end > len(files) {
+			end = len(files)
+		}
+		keys := make([]map[string]dyTypes.AttributeValue, 0, end-start)
+		for _, f := range files[start:end] {
+			keys = append(keys, map[string]dyTypes.AttributeValue{
+				"ManifestId": &dyTypes.AttributeValueMemberS{Value: manifestId},
+				"UploadId":   &dyTypes.AttributeValueMemberS{Value: f.UploadID},
+			})
+		}
+		out, err := dy.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]dyTypes.KeysAndAttributes{
+				fileTable: {
+					Keys:                 keys,
+					ProjectionExpression: aws.String("UploadId, #s"),
+					ExpressionAttributeNames: map[string]string{
+						"#s": "Status",
+					},
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range out.Responses[fileTable] {
+			uid, _ := item["UploadId"].(*dyTypes.AttributeValueMemberS)
+			s, _ := item["Status"].(*dyTypes.AttributeValueMemberS)
+			if uid == nil || s == nil {
+				continue
+			}
+			statuses[uid.Value] = s.Value
+		}
+	}
+	return statuses, nil
+}
+
+// dispatchToUploadLambda synthesizes an SQS event carrying one synthetic S3
+// create event per file and invokes the upload lambda synchronously. Returns
+// the set of uploadIds that the upload lambda failed to import.
+func dispatchToUploadLambda(
+	ctx context.Context,
+	lambdaClient LambdaAPI,
+	uploadLambdaArn string,
+	bucket string,
+	keyPrefix string,
+	files []finalizeFileRequest,
+) (map[string]struct{}, error) {
+	sqsEvent := events.SQSEvent{Records: make([]events.SQSMessage, 0, len(files))}
+	keyToUploadId := make(map[string]string, len(files))
+
+	for _, f := range files {
+		key := fmt.Sprintf("%s/%s", keyPrefix, f.UploadID)
+		keyToUploadId[key] = f.UploadID
+
+		s3Ev := events.S3Event{Records: []events.S3EventRecord{{
+			EventSource: "aws:s3",
+			EventName:   "ObjectCreated:Put",
+			S3: events.S3Entity{
+				Bucket: events.S3Bucket{Name: bucket},
+				Object: events.S3Object{Key: key, Size: f.Size},
+			},
+		}}}
+		body, _ := json.Marshal(s3Ev)
+
+		sqsEvent.Records = append(sqsEvent.Records, events.SQSMessage{
+			MessageId:   f.UploadID,
+			Body:        string(body),
+			EventSource: "aws:sqs",
+			AWSRegion:   os.Getenv("REGION"),
+		})
+	}
+
+	payload, err := json.Marshal(sqsEvent)
+	if err != nil {
+		return nil, fmt.Errorf("marshal sqs event: %w", err)
+	}
+
+	invokeCtx, cancel := context.WithTimeout(ctx, 4*time.Minute)
+	defer cancel()
+
+	out, err := lambdaClient.Invoke(invokeCtx, &lambda.InvokeInput{
+		FunctionName:   aws.String(uploadLambdaArn),
+		InvocationType: lambdaTypes.InvocationTypeRequestResponse,
+		Payload:        payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invoke upload lambda: %w", err)
+	}
+	if out.FunctionError != nil {
+		return nil, fmt.Errorf("upload lambda returned error: %s", strings.TrimSpace(string(out.Payload)))
+	}
+
+	// Upload lambda returns events.SQSEventResponse with BatchItemFailures for
+	// entries the upload lambda couldn't import.
+	var resp events.SQSEventResponse
+	if err := json.Unmarshal(out.Payload, &resp); err != nil {
+		return nil, fmt.Errorf("parse upload lambda response: %w", err)
+	}
+	failed := make(map[string]struct{}, len(resp.BatchItemFailures))
+	for _, f := range resp.BatchItemFailures {
+		// MessageId is set to UploadId above.
+		failed[f.ItemIdentifier] = struct{}{}
+	}
+	return failed, nil
+}

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -91,6 +91,20 @@ func ManifestHandler(request events.APIGatewayV2HTTPRequest) (*events.APIGateway
 				apiResponse, err = postUploadCredentialsRoute(request, claims)
 			}
 		}
+	case "/manifest/storage-credentials":
+		switch request.RequestContext.HTTP.Method {
+		case "POST":
+			if authorized = authorizer.HasRole(*claims, permissions.CreateDeleteFiles); authorized {
+				apiResponse, err = postStorageCredentialsRoute(request, claims)
+			}
+		}
+	case "/manifest/files/finalize":
+		switch request.RequestContext.HTTP.Method {
+		case "POST":
+			if authorized = authorizer.HasRole(*claims, permissions.CreateDeleteFiles); authorized {
+				apiResponse, err = postFinalizeFilesRoute(request, claims)
+			}
+		}
 	case "/manifest/archive":
 		switch request.RequestContext.HTTP.Method {
 		case "GET":

--- a/lambda/service/handler/storage_credentials.go
+++ b/lambda/service/handler/storage_credentials.go
@@ -1,0 +1,187 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/gateway"
+	dyQueries "github.com/pennsieve/pennsieve-go-core/pkg/queries/dydb"
+	pgQueries "github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
+	"github.com/pennsieve/pennsieve-upload-service-v2/service/pkg/storage"
+	log "github.com/sirupsen/logrus"
+)
+
+type storageCredentialsRequest struct {
+	ManifestNodeID string `json:"manifestNodeId"`
+}
+
+type storageCredentialsResponse struct {
+	AccessKeyID     string `json:"accessKeyId"`
+	SecretAccessKey string `json:"secretAccessKey"`
+	SessionToken    string `json:"sessionToken"`
+	Expiration      string `json:"expiration"`
+	Bucket          string `json:"bucket"`
+	KeyPrefix       string `json:"keyPrefix"`
+	Region          string `json:"region"`
+}
+
+// postStorageCredentialsRoute returns STS credentials scoped to the manifest's
+// destination storage bucket + O{org}/D{dataset}/{manifest}/* prefix, so the
+// agent can upload directly to final storage (no intermediate upload bucket).
+func postStorageCredentialsRoute(request events.APIGatewayV2HTTPRequest, claims *authorizer.Claims) (*events.APIGatewayV2HTTPResponse, error) {
+	var req storageCredentialsRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil {
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 400,
+			Body:       gateway.CreateErrorMessage("Invalid request body: "+err.Error(), 400),
+		}, nil
+	}
+	if !isValidUUID(req.ManifestNodeID) {
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 400,
+			Body:       gateway.CreateErrorMessage("manifestNodeId must be a UUID", 400),
+		}, nil
+	}
+
+	ctx := context.Background()
+
+	manifestRecord, err := store.dy.GetManifestById(ctx, store.tableName, req.ManifestNodeID)
+	if err != nil {
+		log.WithError(err).WithField("manifestNodeId", req.ManifestNodeID).Warn("manifest not found")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 404,
+			Body:       gateway.CreateErrorMessage("Manifest not found", 404),
+		}, nil
+	}
+	if manifestRecord.DatasetNodeId != claims.DatasetClaim.NodeId {
+		log.WithFields(log.Fields{
+			"manifestDataset": manifestRecord.DatasetNodeId,
+			"claimsDataset":   claims.DatasetClaim.NodeId,
+		}).Warn("manifest does not belong to the authenticated dataset")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 403,
+			Body:       gateway.CreateErrorMessage("Manifest does not belong to this dataset", 403),
+		}, nil
+	}
+
+	roleARN := os.Getenv("STORAGE_CREDENTIALS_ROLE_ARN")
+	if roleARN == "" {
+		log.Error("STORAGE_CREDENTIALS_ROLE_ARN not configured")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Storage credentials not configured", 500),
+		}, nil
+	}
+	defaultStorageBucket := os.Getenv("DEFAULT_STORAGE_BUCKET")
+	if defaultStorageBucket == "" {
+		log.Error("DEFAULT_STORAGE_BUCKET not configured")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Storage not configured", 500),
+		}, nil
+	}
+	region := os.Getenv("REGION")
+
+	// Resolve destination bucket via shared resolver (workspace-scoped today,
+	// per-dataset in the future).
+	pgdb, err := pgQueries.ConnectRDS()
+	if err != nil {
+		log.WithError(err).Error("failed to connect to RDS")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Internal error", 500),
+		}, nil
+	}
+	defer pgdb.Close()
+
+	resolution, err := storage.ResolveForManifest(
+		ctx,
+		req.ManifestNodeID,
+		store.tableName,
+		defaultStorageBucket,
+		dyQueries.New(store.dynamodb),
+		pgQueries.New(pgdb),
+	)
+	if err != nil {
+		log.WithError(err).WithField("manifestNodeId", req.ManifestNodeID).Error("failed to resolve storage bucket")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Failed to resolve storage bucket", 500),
+		}, nil
+	}
+
+	// Future: if resolver returns a non-S3 backend (Azure, local), return 409 so
+	// the agent can fall back or use a backend-specific auth path. Today all
+	// backends are S3, so this is a no-op until the resolver learns about
+	// multiple backend types.
+	// if resolution.Backend != storage.BackendS3 { ... return 409 ... }
+
+	sessionPolicy := fmt.Sprintf(`{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:ListBucketMultipartUploads",
+				"s3:AbortMultipartUpload",
+				"s3:ListMultipartUploadParts",
+				"s3:PutObjectTagging"
+			],
+			"Resource": [
+				"arn:aws:s3:::%s",
+				"arn:aws:s3:::%s/%s/*"
+			]
+		}]
+	}`, resolution.StorageBucket, resolution.StorageBucket, resolution.KeyPrefix(req.ManifestNodeID))
+
+	sessionName := fmt.Sprintf("storage-%d-%d", claims.OrgClaim.IntId, claims.UserClaim.Id)
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		log.WithError(err).Error("Failed to load AWS config")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Internal error", 500),
+		}, nil
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	durationSeconds := int32(3600)
+	result, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String(sessionName),
+		Policy:          aws.String(sessionPolicy),
+		DurationSeconds: &durationSeconds,
+	})
+	if err != nil {
+		log.WithError(err).Error("Failed to assume storage credentials role")
+		return &events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       gateway.CreateErrorMessage("Failed to generate storage credentials", 500),
+		}, nil
+	}
+
+	resp := storageCredentialsResponse{
+		AccessKeyID:     *result.Credentials.AccessKeyId,
+		SecretAccessKey: *result.Credentials.SecretAccessKey,
+		SessionToken:    *result.Credentials.SessionToken,
+		Expiration:      result.Credentials.Expiration.Format(time.RFC3339),
+		Bucket:          resolution.StorageBucket,
+		KeyPrefix:       resolution.KeyPrefix(req.ManifestNodeID),
+		Region:          region,
+	}
+
+	jsonBody, _ := json.Marshal(resp)
+	return &events.APIGatewayV2HTTPResponse{
+		StatusCode: 200,
+		Body:       string(jsonBody),
+	}, nil
+}

--- a/lambda/service/handler/upload_credentials.go
+++ b/lambda/service/handler/upload_credentials.go
@@ -38,10 +38,10 @@ func postUploadCredentialsRoute(request events.APIGatewayV2HTTPRequest, claims *
 		}, nil
 	}
 
-	if req.ManifestNodeID == "" {
+	if !isValidUUID(req.ManifestNodeID) {
 		return &events.APIGatewayV2HTTPResponse{
 			StatusCode: 400,
-			Body:       gateway.CreateErrorMessage("manifestNodeId is required", 400),
+			Body:       gateway.CreateErrorMessage("manifestNodeId must be a UUID", 400),
 		}, nil
 	}
 

--- a/lambda/service/handler/validation.go
+++ b/lambda/service/handler/validation.go
@@ -1,0 +1,15 @@
+package handler
+
+import "regexp"
+
+// uuidRE matches the canonical 8-4-4-4-12 hex UUID format used for manifest
+// and upload identifiers throughout the platform. Validation guards against
+// callers embedding arbitrary strings into contexts that interpret special
+// characters — notably the STS session policy constructed in
+// storage_credentials.go, where a JSON-escaping payload could widen the
+// policy scope.
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func isValidUUID(s string) bool {
+	return uuidRE.MatchString(s)
+}

--- a/lambda/service/pkg/storage/resolver.go
+++ b/lambda/service/pkg/storage/resolver.go
@@ -1,0 +1,65 @@
+// Package storage resolves the destination storage bucket and prefix for a manifest.
+//
+// Today the bucket is scoped per-workspace (Organization.StorageBucket); in the
+// near future it will be scoped per-dataset. Keeping the resolver keyed on
+// manifestId means that switch is a single-site change.
+//
+// Duplicates fargate/upload-move/cache.go:DefaultStorageOrgItemQuery because
+// the fargate and service-lambda Go modules pin different pennsieve-go-core
+// versions. The two implementations are intentionally kept in lock-step; unify
+// them when the per-dataset redesign lands.
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pennsieve/pennsieve-go-core/pkg/queries/dydb"
+	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
+)
+
+// Resolution describes where files for a given manifest must be written.
+type Resolution struct {
+	OrganizationId int64
+	DatasetId      int64
+	StorageBucket  string
+}
+
+// KeyPrefix returns the full object-key prefix used for files in this manifest.
+// Format: O{orgId}/D{datasetId}/{manifestId}.
+func (r Resolution) KeyPrefix(manifestId string) string {
+	return fmt.Sprintf("O%d/D%d/%s", r.OrganizationId, r.DatasetId, manifestId)
+}
+
+// ResolveForManifest looks up the storage bucket + org/dataset ids for a manifest.
+// Falls back to defaultStorageBucket when the organization has no StorageBucket override.
+func ResolveForManifest(
+	ctx context.Context,
+	manifestId string,
+	manifestTableName string,
+	defaultStorageBucket string,
+	dy *dydb.Queries,
+	pg *pgdb.Queries,
+) (*Resolution, error) {
+	manifest, err := dy.GetManifestById(ctx, manifestTableName, manifestId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting manifest %s: %w", manifestId, err)
+	}
+
+	org, err := pg.GetOrganization(ctx, manifest.OrganizationId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization %d referenced in manifest %s: %w",
+			manifest.OrganizationId, manifestId, err)
+	}
+
+	bucket := defaultStorageBucket
+	if org.StorageBucket.Valid {
+		bucket = org.StorageBucket.String
+	}
+
+	return &Resolution{
+		OrganizationId: manifest.OrganizationId,
+		DatasetId:      manifest.DatasetId,
+		StorageBucket:  bucket,
+	}, nil
+}

--- a/lambda/upload/handler/dyQueries.go
+++ b/lambda/upload/handler/dyQueries.go
@@ -249,6 +249,12 @@ func (q *UploadDyQueries) GetUploadFiles(entries []UploadEntry) ([]uploadFile.Up
 
 // updateManifest updates the manifestFiles to IMPORTED status and updates other fields.
 func (q *UploadDyQueries) updateManifestFileStatus(uploadFilesForManifest []uploadFile.UploadFile, manifestId string) error {
+	return q.updateManifestFileStatusTo(uploadFilesForManifest, manifestId, manifestFile.Imported)
+}
+
+// updateManifestFileStatusTo is like updateManifestFileStatus but lets the caller pick the target status.
+// Direct-to-storage uploads skip the Fargate move and go straight to Finalized.
+func (q *UploadDyQueries) updateManifestFileStatusTo(uploadFilesForManifest []uploadFile.UploadFile, manifestId string, targetStatus manifestFile.Status) error {
 
 	// Update status of files in dynamoDB
 	var fileDTOs []manifestFile.FileDTO
@@ -258,7 +264,7 @@ func (q *UploadDyQueries) updateManifestFileStatus(uploadFilesForManifest []uplo
 			S3Key:          u.S3Key,
 			TargetPath:     u.Path,
 			TargetName:     u.Name,
-			Status:         manifestFile.Imported,
+			Status:         targetStatus,
 			MergePackageId: u.MergePackageId,
 			FileType:       u.FileType.String(),
 		}
@@ -268,14 +274,14 @@ func (q *UploadDyQueries) updateManifestFileStatus(uploadFilesForManifest []uplo
 	// We are replacing the entries instead of updating the status field as
 	// this is the only way we can batch update, and we also update the name in
 	// case that we need to append index (on name conflict).
-	setStatus := manifestFile.Imported
+	setStatus := targetStatus
 	stats, err := q.SyncFiles(manifestId, fileDTOs, &setStatus, ManifestTableName, ManifestFileTableName)
 	if err != nil {
 		return err
 	}
 
 	if stats.NrFilesUpdated != len(uploadFilesForManifest) {
-		return errors.New("could not update status for manifest files to IMPORTED")
+		return fmt.Errorf("could not update status for manifest files to %s", targetStatus.String())
 	}
 
 	return nil

--- a/lambda/upload/handler/models.go
+++ b/lambda/upload/handler/models.go
@@ -36,4 +36,8 @@ type UploadEntry struct {
 	MergePackageId string
 	FileType       string
 	Sha256         string
+	// DirectToStorage indicates the file already landed at its final storage
+	// location (agent uploaded directly, no Fargate move required). Detected
+	// from the S3 key prefix (starts with "O{orgId}/D{datasetId}/...").
+	DirectToStorage bool
 }

--- a/lambda/upload/handler/s3.go
+++ b/lambda/upload/handler/s3.go
@@ -10,6 +10,7 @@ import (
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	log "github.com/sirupsen/logrus"
 	"regexp"
+	"strings"
 )
 
 // GetUploadEntries parses the events from SQS into meaningful objects
@@ -72,7 +73,19 @@ func (s *UploadHandlerStore) GetUploadEntries(fileEvents []events.SQSMessage) ([
 }
 
 // uploadEntryFromS3Event returns an object representing an uploaded file from an S3 Event.
+//
+// Accepts two key shapes:
+//   - Legacy (upload bucket): {manifestId}/{uploadId}
+//   - Direct-to-storage: O{orgId}/D{datasetId}/{manifestId}/{uploadId}
+//
+// Only the trailing manifest/upload pair is extracted — the leading O/D segments
+// carry the same org+dataset already stored on the manifest record, so they're
+// informational here.
 func (s *UploadHandlerStore) uploadEntryFromS3Event(event *events.S3Event) (*UploadEntry, error) {
+	// No end anchor: legacy cross-account clients (data-target-pennsieve) may
+	// use nested keys like {manifestId}/{uploadId}/subpath/file, which the
+	// upload-credentials session policy permits. FindStringSubmatch returns
+	// the first match, so we still extract manifest/upload reliably.
 	r := regexp.MustCompile(`(?P<Manifest>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\/(?P<UploadId>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})`)
 	res := r.FindStringSubmatch(event.Records[0].S3.Object.Key)
 
@@ -107,14 +120,19 @@ func (s *UploadHandlerStore) uploadEntryFromS3Event(event *events.S3Event) (*Upl
 		}
 	}
 
+	// Keys starting with "O" (e.g. O42/D17/{manifest}/{upload}) signal the file
+	// already landed at final storage via direct upload; no Fargate move needed.
+	directToStorage := strings.HasPrefix(s3Key, "O")
+
 	response := UploadEntry{
-		S3Bucket:   s3Bucket,
-		S3Key:      s3Key,
-		ManifestId: manifestId,
-		UploadId:   uploadId,
-		ETag:       event.Records[0].S3.Object.ETag,
-		Size:       event.Records[0].S3.Object.Size,
-		Sha256:     checkSumOrEmpty(result.ChecksumSHA256),
+		S3Bucket:        s3Bucket,
+		S3Key:           s3Key,
+		ManifestId:      manifestId,
+		UploadId:        uploadId,
+		ETag:            event.Records[0].S3.Object.ETag,
+		Size:            event.Records[0].S3.Object.Size,
+		Sha256:          checkSumOrEmpty(result.ChecksumSHA256),
+		DirectToStorage: directToStorage,
 	}
 
 	log.WithFields(

--- a/lambda/upload/handler/s3_regex_test.go
+++ b/lambda/upload/handler/s3_regex_test.go
@@ -1,0 +1,49 @@
+// External test package — avoids the in-package TestMain that requires live
+// DynamoDB/Postgres for the integration tests.
+package handler_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKeyRegex confirms the regex used in uploadEntryFromS3Event accepts both
+// the legacy upload-bucket key shape, the direct-to-storage shape, and nested
+// sub-paths permitted by the upload-credentials session policy. Kept in sync
+// with the literal in handler/s3.go by copy; integration tests (s3_test.go)
+// exercise the live path.
+func TestKeyRegex(t *testing.T) {
+	r := regexp.MustCompile(`(?P<Manifest>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\/(?P<UploadId>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})`)
+
+	manifestId := "00000000-0000-0000-0000-000000000000"
+	uploadId := "00000000-1111-1111-1111-000000000000"
+
+	cases := []struct {
+		name  string
+		key   string
+		match bool
+	}{
+		{"legacy upload bucket", manifestId + "/" + uploadId, true},
+		{"direct to storage", "O42/D17/" + manifestId + "/" + uploadId, true},
+		{"direct to storage large ids", "O1234567/D7654321/" + manifestId + "/" + uploadId, true},
+		{"nested subpath (data-target compat)", manifestId + "/" + uploadId + "/extracted/file.csv", true},
+		{"malformed no manifest", "not-a-uuid/not-a-uuid", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := r.FindStringSubmatch(tc.key)
+			if !tc.match {
+				assert.Nil(t, res, "unexpected match for %q", tc.key)
+				return
+			}
+			if !assert.NotNil(t, res, "expected match for %q", tc.key) {
+				return
+			}
+			assert.Equal(t, manifestId, res[r.SubexpIndex("Manifest")])
+			assert.Equal(t, uploadId, res[r.SubexpIndex("UploadId")])
+		})
+	}
+}

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/domain"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dydb"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/fileInfo/objectType"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
@@ -125,8 +126,12 @@ func (s *UploadHandlerStore) execTx(ctx context.Context, fn func(queries *Upload
 
 // ImportFiles creates rows for uploaded files in Packages and Files tables as a transaction
 // All files belong to a single manifest, and therefor single dataset in a single organization.
+//
+// When directToStorage is true, the files already landed at final storage (the
+// agent uploaded straight to the storage bucket), so SNS publish is skipped —
+// there's nothing for the Fargate move task to do.
 func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, orgId int, user pgdb.User,
-	files []uploadFile.UploadFile, manifest *dydb.ManifestTable) error {
+	files []uploadFile.UploadFile, manifest *dydb.ManifestTable, directToStorage bool) error {
 
 	contextLogger := log.WithFields(log.Fields{
 		"service":     "Upload-service",
@@ -289,10 +294,13 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 		log.Debug(fmt.Sprintf("Package %d storage incremented by %d", p, v))
 	}
 
-	// 5. Notify SNS that files were imported.
-	err = s.PublishToSNS(result.files)
-	if err != nil {
-		contextLogger.Error("Error with notifying SNS that records are imported.", err)
+	// 5. Notify SNS that files were imported — triggers the Fargate move task.
+	// Skip for direct-to-storage: files are already at final location.
+	if !directToStorage {
+		err = s.PublishToSNS(result.files)
+		if err != nil {
+			contextLogger.Error("Error with notifying SNS that records are imported.", err)
+		}
 	}
 
 	// 6. Update activity Log
@@ -453,7 +461,19 @@ func (s *UploadHandlerStore) Handler(ctx context.Context, sqsEvent events.SQSEve
 			continue
 		}
 
-		err = s.ImportFiles(ctx, int(manifest.DatasetId), int(manifest.OrganizationId), *user, uploadFilesForManifest, manifest)
+		// Detect whether this manifest-batch came in via direct-to-storage
+		// upload (key starts with "O...") or the legacy upload-bucket path.
+		// All files in a single manifest-batch share the same origin.
+		direct := len(uploadFilesForManifest) > 0 && strings.HasPrefix(uploadFilesForManifest[0].S3Key, "O")
+
+		// Direct-to-storage goes straight to Finalized (no Fargate move).
+		// Legacy goes to Imported so Fargate picks them up for the move.
+		targetStatus := manifestFile.Imported
+		if direct {
+			targetStatus = manifestFile.Finalized
+		}
+
+		err = s.ImportFiles(ctx, int(manifest.DatasetId), int(manifest.OrganizationId), *user, uploadFilesForManifest, manifest, direct)
 		if err != nil {
 			contextLogger.Error("Error in batch create packages: ", err)
 
@@ -461,7 +481,7 @@ func (s *UploadHandlerStore) Handler(ctx context.Context, sqsEvent events.SQSEve
 			// This will ensure that only the files that cause the failure will be returned to the sqs queue
 			for _, f := range uploadFilesForManifest {
 				singleFileArr := []uploadFile.UploadFile{f}
-				err = s.ImportFiles(ctx, int(manifest.DatasetId), int(manifest.OrganizationId), *user, singleFileArr, manifest)
+				err = s.ImportFiles(ctx, int(manifest.DatasetId), int(manifest.OrganizationId), *user, singleFileArr, manifest, direct)
 				if err != nil {
 					batchItemFailures = addToFailedFiles(singleFileArr, s3KeySQSMessageMap, batchItemFailures)
 					contextLogger.WithFields(
@@ -472,8 +492,8 @@ func (s *UploadHandlerStore) Handler(ctx context.Context, sqsEvent events.SQSEve
 					continue
 				}
 
-				// Update entries in manifest to IMPORTED for single file
-				err = s.dy.updateManifestFileStatus(singleFileArr, manifestId)
+				// Update entries in manifest to target status for single file
+				err = s.dy.updateManifestFileStatusTo(singleFileArr, manifestId, targetStatus)
 				if err != nil {
 					// Status is not correctly updated in Manifest but files are completely imported.
 					// This should not return the failed files.
@@ -484,8 +504,8 @@ func (s *UploadHandlerStore) Handler(ctx context.Context, sqsEvent events.SQSEve
 			continue
 		}
 
-		// Update entries in manifest to IMPORTED for all files
-		err = s.dy.updateManifestFileStatus(uploadFilesForManifest, manifestId)
+		// Update entries in manifest to target status for all files
+		err = s.dy.updateManifestFileStatusTo(uploadFilesForManifest, manifestId, targetStatus)
 		if err != nil {
 			// Status is not correctly updated in Manifest but files are completely imported.
 			// This should not return the failed files.

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -307,7 +307,7 @@ func testImportFilesSingleFile(t *testing.T, orgID int, store *UploadHandlerStor
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 1) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "file1.txt", "parent_id": nil})
 		}
@@ -360,7 +360,7 @@ func testImportFilesSingleFileInFolder(t *testing.T, orgID int, store *UploadHan
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		// One package for the folder and one for the file
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 2) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "dir1", "parent_id": nil})
@@ -416,7 +416,7 @@ func testImportFilesSingleWithLeadingSlash(t *testing.T, orgID int, store *Uploa
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		// There should only be one package since the path is "/", the import should not create a containing folder.
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 1) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "file1.txt", "parent_id": nil})
@@ -470,7 +470,7 @@ func testImportFilesSingleInFolderWithLeadingSlash(t *testing.T, orgID int, stor
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		// Two packages: dir1 and file1.txt
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 2) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages", map[string]any{"name": "dir1", "parent_id": nil})
@@ -576,7 +576,7 @@ func testImportFiles(t *testing.T, orgID int, store *UploadHandlerStore) {
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 7) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages",
 				map[string]any{"name": "root1.txt", "parent_id": nil})
@@ -699,7 +699,7 @@ func testImportFilesWithLeadingSlash(t *testing.T, orgID int, store *UploadHandl
 		},
 	}
 
-	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest)) {
+	if assert.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false)) {
 		if test.AssertRowCount(t, store.pgdb, orgID, "packages", 7) {
 			test.AssertExistsOneWhere(t, store.pgdb, orgID, "packages",
 				map[string]any{"name": "root1.txt", "parent_id": nil})

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_fargate_group_subs
 resource "aws_cloudwatch_log_group" "upload_lambda_loggroup" {
   name              = "/aws/lambda/${aws_lambda_function.upload_lambda.function_name}"
   retention_in_days = 30
-  tags = local.common_tags
+  tags              = local.common_tags
 }
 
 // Send logs from upload trigger lambda to datadog
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_group_subscrip
 resource "aws_cloudwatch_log_group" "upload_service_lambda_loggroup" {
   name              = "/aws/lambda/${aws_lambda_function.service_lambda.function_name}"
   retention_in_days = 30
-  tags = local.common_tags
+  tags              = local.common_tags
 }
 
 // Send logs from upload trigger service to datadog
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_upload_service_gro
 resource "aws_cloudwatch_log_group" "archiver_lambda_loggroup" {
   name              = "/aws/lambda/${aws_lambda_function.archive_lambda.function_name}"
   retention_in_days = 7
-  tags = local.common_tags
+  tags              = local.common_tags
 }
 
 // Send logs from upload trigger service to datadog

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -3,7 +3,7 @@ resource "aws_cognito_identity_pool" "pennsieve_auth" {
   allow_unauthenticated_identities = false
   allow_classic_flow               = false
 
-  cognito_identity_providers  {
+  cognito_identity_providers {
     client_id               = data.terraform_remote_state.authentication_service.outputs.token_pool_client_id
     provider_name           = "cognito-idp.${var.aws_region}.amazonaws.com/${data.terraform_remote_state.authentication_service.outputs.token_pool_id}"
     server_side_token_check = false
@@ -20,7 +20,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
   identity_pool_id = aws_cognito_identity_pool.pennsieve_auth.id
 
   roles = {
-    "authenticated" = aws_iam_role.cognito_identity_auth_role.arn
+    "authenticated"   = aws_iam_role.cognito_identity_auth_role.arn
     "unauthenticated" = aws_iam_role.cognito_identity_unauth_role.arn
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,8 +1,8 @@
 ## Create Upload Manifest Dynamo Table
 resource "aws_dynamodb_table" "manifest_dynamo_table" {
-  name           = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  billing_mode   = "PAY_PER_REQUEST"
-  hash_key       = "ManifestId"
+  name         = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "ManifestId"
 
   attribute {
     name = "ManifestId"
@@ -20,10 +20,10 @@ resource "aws_dynamodb_table" "manifest_dynamo_table" {
   }
 
   global_secondary_index {
-    name               = "DatasetManifestIndex"
-    hash_key           = "DatasetNodeId"
-    range_key          = "UserId"
-    projection_type    = "ALL"
+    name            = "DatasetManifestIndex"
+    hash_key        = "DatasetNodeId"
+    range_key       = "UserId"
+    projection_type = "ALL"
   }
 
   point_in_time_recovery {
@@ -35,21 +35,21 @@ resource "aws_dynamodb_table" "manifest_dynamo_table" {
   }
 
   tags = merge(
-  local.common_tags,
-  {
-    "Name"         = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "name"         = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "service_name" = var.service_name
-  },
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-manifest-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = var.service_name
+    },
   )
 }
 
 # Create Manifest Files Dynamo Table
 resource "aws_dynamodb_table" "manifest_files_dynamo_table" {
-  name           = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  billing_mode   = "PAY_PER_REQUEST"
-  hash_key       = "ManifestId"
-  range_key      = "UploadId"
+  name         = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "ManifestId"
+  range_key    = "UploadId"
 
   attribute {
     name = "ManifestId"
@@ -124,11 +124,11 @@ resource "aws_dynamodb_table" "manifest_files_dynamo_table" {
   }
 
   tags = merge(
-  local.common_tags,
-  {
-    "Name"         = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "name"         = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "service_name" = var.service_name
-  },
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-manifest-files-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = var.service_name
+    },
   )
 }

--- a/terraform/fargate.tf
+++ b/terraform/fargate.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
   family                   = "${var.environment_name}-${var.service_name}-${var.tier}-task-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  container_definitions    = templatefile("${path.module}/task_definition.json.tpl", {
+  container_definitions = templatefile("${path.module}/task_definition.json.tpl", {
     aws_region                = data.aws_region.current_region.name
     aws_region_shortname      = data.terraform_remote_state.region.outputs.aws_region_shortname
     container_cpu             = var.container_cpu

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -4,16 +4,16 @@ resource "aws_apigatewayv2_api" "upload_service_api" {
   description   = "API for creating and initiating upload manifests. Use this API to inform the platform of the files you are about to upload. This is required in order to upload files to the platform."
   cors_configuration {
     allow_origins     = local.cors_allowed_origins
-    allow_methods = ["OPTIONS", "GET", "POST", "PATCH", "DELETE"]
-    allow_headers = ["*"]
+    allow_methods     = ["OPTIONS", "GET", "POST", "PATCH", "DELETE"]
+    allow_headers     = ["*"]
     allow_credentials = true
-    expose_headers = ["*"]
+    expose_headers    = ["*"]
     max_age           = 300
   }
   body = templatefile("${path.module}/upload-service.yml", {
-    authorize_lambda_invoke_uri    = data.terraform_remote_state.api_gateway.outputs.authorizer_lambda_invoke_uri
-    gateway_authorizer_role        = data.terraform_remote_state.api_gateway.outputs.authorizer_invocation_role
-    upload_service_lambda_arn     = aws_lambda_function.service_lambda.arn
+    authorize_lambda_invoke_uri = data.terraform_remote_state.api_gateway.outputs.authorizer_lambda_invoke_uri
+    gateway_authorizer_role     = data.terraform_remote_state.api_gateway.outputs.authorizer_invocation_role
+    upload_service_lambda_arn   = aws_lambda_function.service_lambda.arn
   })
 }
 
@@ -45,7 +45,7 @@ resource "aws_apigatewayv2_stage" "upload_service_gateway_stage" {
       status                  = "$context.status"
       responseLength          = "$context.responseLength"
       integrationErrorMessage = "$context.integrationErrorMessage"
-    }
+      }
     )
   }
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "upload_service_v2_kms_key_policy_document" {
     ]
 
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         aws_iam_role.upload_service_v2_lambda_role.arn
       ]
@@ -141,7 +141,7 @@ data "aws_iam_policy_document" "upload_service_v2_iam_policy_document" {
   }
 
   statement {
-    sid = "ArchiverBucketAccess"
+    sid    = "ArchiverBucketAccess"
     effect = "Allow"
 
     actions = [
@@ -221,11 +221,11 @@ data "aws_iam_policy_document" "upload_service_v2_iam_policy_document" {
 
     resources = [
       "arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment_name}/${var.service_name}/*",
-      "arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/ops/*"]
+    "arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/ops/*"]
   }
 
   statement {
-    sid = "LambdaAccessToDynamoDB"
+    sid    = "LambdaAccessToDynamoDB"
     effect = "Allow"
 
     actions = [
@@ -313,7 +313,7 @@ data "aws_iam_policy_document" "upload_service_v2_iam_policy_document" {
   }
 
   statement {
-    sid = "InvokeLambdaPermission"
+    sid    = "InvokeLambdaPermission"
     effect = "Allow"
 
     actions = [
@@ -322,7 +322,8 @@ data "aws_iam_policy_document" "upload_service_v2_iam_policy_document" {
     ]
 
     resources = [
-      aws_lambda_function.archive_lambda.arn
+      aws_lambda_function.archive_lambda.arn,
+      aws_lambda_function.upload_lambda.arn,
     ]
 
   }
@@ -336,7 +337,8 @@ data "aws_iam_policy_document" "upload_service_v2_iam_policy_document" {
     ]
 
     resources = [
-      aws_iam_role.upload_credentials_role.arn
+      aws_iam_role.upload_credentials_role.arn,
+      aws_iam_role.storage_credentials_role.arn,
     ]
   }
 
@@ -393,6 +395,80 @@ data "aws_iam_policy_document" "upload_credentials_policy_document" {
       "${aws_s3_bucket.uploads_s3_bucket.arn}/*"
     ]
   }
+}
+
+##############################
+# STORAGE CREDENTIALS ROLE   #
+##############################
+# Assumed by the service lambda to mint temporary credentials scoped to a
+# specific manifest's destination storage bucket + O{org}/D{ds}/{manifest}/*
+# prefix. Lets agents upload direct-to-storage without staging through the
+# upload bucket.
+
+resource "aws_iam_role" "storage_credentials_role" {
+  name = "${var.environment_name}-${var.service_name}-storage-credentials-role-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.upload_service_v2_lambda_role.arn
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Static storage buckets (platform-infra owned). Dynamic workspace buckets are
+# attached below via the account-service managed policy, which is updated as
+# storage nodes are provisioned.
+resource "aws_iam_role_policy_attachment" "storage_credentials_static_buckets" {
+  role       = aws_iam_role.storage_credentials_role.name
+  policy_arn = aws_iam_policy.storage_credentials_static_policy.arn
+}
+
+resource "aws_iam_policy" "storage_credentials_static_policy" {
+  name   = "${var.environment_name}-${var.service_name}-storage-credentials-static-policy-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  policy = data.aws_iam_policy_document.storage_credentials_static_policy_document.json
+}
+
+data "aws_iam_policy_document" "storage_credentials_static_policy_document" {
+  statement {
+    sid    = "StaticStorageBucketsWriteAccess"
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObjectTagging"
+    ]
+
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
+      data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,
+      "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn}/*",
+    ]
+  }
+}
+
+# Dynamic storage buckets (workspace-scoped, account-service managed). The
+# same managed policy is also attached to the Fargate move role at the bottom
+# of this file.
+resource "aws_iam_role_policy_attachment" "storage_credentials_dynamic_buckets" {
+  role       = aws_iam_role.storage_credentials_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_write_policy_arn
 }
 
 ##############################
@@ -535,7 +611,7 @@ data "aws_iam_policy_document" "move_trigger_iam_policy_document" {
   }
 
   statement {
-    sid = "LambdaAccessToDynamoDB"
+    sid    = "LambdaAccessToDynamoDB"
     effect = "Allow"
 
     actions = [
@@ -667,7 +743,7 @@ data "aws_iam_policy_document" "upload_fargate_iam_policy_document" {
   }
 
   statement {
-    sid = "LambdaAccessToDynamoDB"
+    sid    = "LambdaAccessToDynamoDB"
     effect = "Allow"
 
     actions = [

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,15 +1,15 @@
 ## Lambda Function which consumes messages from the SQS queue which contains all events.
 resource "aws_lambda_function" "upload_lambda" {
-  description      = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
-  function_name    = "${var.environment_name}-${var.service_name}-upload-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "bootstrap"
-  runtime          = "provided.al2023"
-  architectures    = ["arm64"]
-  role             = aws_iam_role.upload_service_v2_lambda_role.arn
-  timeout          = 300
-  memory_size      = 128
-  s3_bucket         = var.lambda_bucket
-  s3_key            = "${var.service_name}/upload/upload-v2-handler-${var.image_tag}.zip"
+  description                    = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
+  function_name                  = "${var.environment_name}-${var.service_name}-upload-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  handler                        = "bootstrap"
+  runtime                        = "provided.al2023"
+  architectures                  = ["arm64"]
+  role                           = aws_iam_role.upload_service_v2_lambda_role.arn
+  timeout                        = 300
+  memory_size                    = 128
+  s3_bucket                      = var.lambda_bucket
+  s3_key                         = "${var.service_name}/upload/upload-v2-handler-${var.image_tag}.zip"
   reserved_concurrent_executions = 100 // Set a maximum concurrency to prevent overloading RDS interaction
 
   vpc_config {
@@ -19,15 +19,15 @@ resource "aws_lambda_function" "upload_lambda" {
 
   environment {
     variables = {
-      ENV = var.environment_name
-      PENNSIEVE_DOMAIN = data.terraform_remote_state.account.outputs.domain_name,
-      MANIFEST_TABLE = aws_dynamodb_table.manifest_dynamo_table.name,
+      ENV                 = var.environment_name
+      PENNSIEVE_DOMAIN    = data.terraform_remote_state.account.outputs.domain_name,
+      MANIFEST_TABLE      = aws_dynamodb_table.manifest_dynamo_table.name,
       MANIFEST_FILE_TABLE = aws_dynamodb_table.manifest_files_dynamo_table.name,
-      IMPORTED_SNS_TOPIC = aws_sns_topic.imported_file_sns_topic.arn,
-      JOBS_QUEUE_ID = data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_id,
-      REGION = var.aws_region,
-      RDS_PROXY_ENDPOINT = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
-      LOG_LEVEL = "info",
+      IMPORTED_SNS_TOPIC  = aws_sns_topic.imported_file_sns_topic.arn,
+      JOBS_QUEUE_ID       = data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_id,
+      REGION              = var.aws_region,
+      RDS_PROXY_ENDPOINT  = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
+      LOG_LEVEL           = "info",
     }
   }
 }
@@ -36,16 +36,16 @@ resource "aws_lambda_function" "upload_lambda" {
 
 ## Lambda Function which consumes messages from the SQS queue which contains all events.
 resource "aws_lambda_function" "service_lambda" {
-  description      = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
-  function_name    = "${var.environment_name}-${var.service_name}-service-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "bootstrap"
-  runtime          = "provided.al2023"
-  architectures    = ["arm64"]
-  role             = aws_iam_role.upload_service_v2_lambda_role.arn
-  timeout          = 300
-  memory_size      = 128
-  s3_bucket         = var.lambda_bucket
-  s3_key            = "${var.service_name}/service/upload-v2-service-${var.image_tag}.zip"
+  description   = "Lambda Function which consumes messages from the SQS queue related to newly uploaded files."
+  function_name = "${var.environment_name}-${var.service_name}-service-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  role          = aws_iam_role.upload_service_v2_lambda_role.arn
+  timeout       = 300
+  memory_size   = 512
+  s3_bucket     = var.lambda_bucket
+  s3_key        = "${var.service_name}/service/upload-v2-service-${var.image_tag}.zip"
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
@@ -54,17 +54,20 @@ resource "aws_lambda_function" "service_lambda" {
 
   environment {
     variables = {
-      ENV = var.environment_name
-      ARCHIVE_BUCKET = aws_s3_bucket.manifest_archive_bucket.id,
-      PENNSIEVE_DOMAIN = data.terraform_remote_state.account.outputs.domain_name,
-      MANIFEST_TABLE = aws_dynamodb_table.manifest_dynamo_table.name,
-      MANIFEST_FILE_TABLE = aws_dynamodb_table.manifest_files_dynamo_table.name,
-      REGION = var.aws_region
-      RDS_PROXY_ENDPOINT = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
-      ARCHIVER_INVOKE_ARN = aws_lambda_function.archive_lambda.arn,
-      UPLOAD_CREDENTIALS_ROLE_ARN = aws_iam_role.upload_credentials_role.arn,
-      UPLOAD_BUCKET = aws_s3_bucket.uploads_s3_bucket.bucket,
-      LOG_LEVEL = "info",
+      ENV                          = var.environment_name
+      ARCHIVE_BUCKET               = aws_s3_bucket.manifest_archive_bucket.id,
+      PENNSIEVE_DOMAIN             = data.terraform_remote_state.account.outputs.domain_name,
+      MANIFEST_TABLE               = aws_dynamodb_table.manifest_dynamo_table.name,
+      MANIFEST_FILE_TABLE          = aws_dynamodb_table.manifest_files_dynamo_table.name,
+      REGION                       = var.aws_region
+      RDS_PROXY_ENDPOINT           = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
+      ARCHIVER_INVOKE_ARN          = aws_lambda_function.archive_lambda.arn,
+      UPLOAD_CREDENTIALS_ROLE_ARN  = aws_iam_role.upload_credentials_role.arn,
+      STORAGE_CREDENTIALS_ROLE_ARN = aws_iam_role.storage_credentials_role.arn,
+      UPLOAD_BUCKET                = aws_s3_bucket.uploads_s3_bucket.bucket,
+      DEFAULT_STORAGE_BUCKET       = data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_id,
+      UPLOAD_LAMBDA_ARN            = aws_lambda_function.upload_lambda.arn,
+      LOG_LEVEL                    = "info",
     }
   }
 }
@@ -72,16 +75,16 @@ resource "aws_lambda_function" "service_lambda" {
 ### ARCHIVE MANIFEST LAMBDA
 ## Lambda Function which archives a manifest
 resource "aws_lambda_function" "archive_lambda" {
-  description      = "Lambda Function which archives a manifest when triggered by the service."
-  function_name    = "${var.environment_name}-${var.service_name}-archive-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  handler          = "bootstrap"
-  runtime          = "provided.al2023"
-  architectures    = ["arm64"]
-  role             = aws_iam_role.upload_service_v2_lambda_role.arn
-  timeout          = 600
-  memory_size      = 128
-  s3_bucket         = var.lambda_bucket
-  s3_key            = "${var.service_name}/archiver/manifest-archiver-${var.image_tag}.zip"
+  description   = "Lambda Function which archives a manifest when triggered by the service."
+  function_name = "${var.environment_name}-${var.service_name}-archive-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  role          = aws_iam_role.upload_service_v2_lambda_role.arn
+  timeout       = 600
+  memory_size   = 128
+  s3_bucket     = var.lambda_bucket
+  s3_key        = "${var.service_name}/archiver/manifest-archiver-${var.image_tag}.zip"
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
@@ -90,14 +93,14 @@ resource "aws_lambda_function" "archive_lambda" {
 
   environment {
     variables = {
-      ENV = var.environment_name
-      ARCHIVE_BUCKET = aws_s3_bucket.manifest_archive_bucket.id,
-      PENNSIEVE_DOMAIN = data.terraform_remote_state.account.outputs.domain_name,
-      MANIFEST_TABLE = aws_dynamodb_table.manifest_dynamo_table.name,
+      ENV                 = var.environment_name
+      ARCHIVE_BUCKET      = aws_s3_bucket.manifest_archive_bucket.id,
+      PENNSIEVE_DOMAIN    = data.terraform_remote_state.account.outputs.domain_name,
+      MANIFEST_TABLE      = aws_dynamodb_table.manifest_dynamo_table.name,
       MANIFEST_FILE_TABLE = aws_dynamodb_table.manifest_files_dynamo_table.name,
-      REGION = var.aws_region
-      RDS_PROXY_ENDPOINT = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
-      LOG_LEVEL = "info",
+      REGION              = var.aws_region
+      RDS_PROXY_ENDPOINT  = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
+      LOG_LEVEL           = "info",
     }
   }
 }
@@ -105,17 +108,17 @@ resource "aws_lambda_function" "archive_lambda" {
 
 ### MOVE TRIGGER
 resource "aws_lambda_function" "fargate_trigger_lambda" {
-  description      = "Lambda Function which triggers FARGATE to move files to final destination."
-  function_name    = "${var.environment_name}-${var.service_name}-fargate-trigger-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  description                    = "Lambda Function which triggers FARGATE to move files to final destination."
+  function_name                  = "${var.environment_name}-${var.service_name}-fargate-trigger-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   reserved_concurrent_executions = 1 // don't allow concurrent lambda's
-  handler          = "bootstrap"
-  runtime          = "provided.al2023"
-  architectures    = ["arm64"]
-  role             = aws_iam_role.move_trigger_lambda_role.arn
-  timeout          = 300
-  memory_size      = 128
-  s3_bucket         = var.lambda_bucket
-  s3_key            = "${var.service_name}/trigger/upload-v2-move-trigger-${var.image_tag}.zip"
+  handler                        = "bootstrap"
+  runtime                        = "provided.al2023"
+  architectures                  = ["arm64"]
+  role                           = aws_iam_role.move_trigger_lambda_role.arn
+  timeout                        = 300
+  memory_size                    = 128
+  s3_bucket                      = var.lambda_bucket
+  s3_key                         = "${var.service_name}/trigger/upload-v2-move-trigger-${var.image_tag}.zip"
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
@@ -124,14 +127,14 @@ resource "aws_lambda_function" "fargate_trigger_lambda" {
 
   environment {
     variables = {
-      ENV = var.environment_name
-      TASK_DEF_ARN = aws_ecs_task_definition.ecs_task_definition.arn,
-      CLUSTER_ARN = data.terraform_remote_state.fargate.outputs.ecs_cluster_arn,
-      SUBNET_IDS = join(",", data.terraform_remote_state.vpc.outputs.private_subnet_ids),
-      SECURITY_GROUP = data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_fargate_security_group_id,
-      REGION = var.aws_region,
+      ENV                = var.environment_name
+      TASK_DEF_ARN       = aws_ecs_task_definition.ecs_task_definition.arn,
+      CLUSTER_ARN        = data.terraform_remote_state.fargate.outputs.ecs_cluster_arn,
+      SUBNET_IDS         = join(",", data.terraform_remote_state.vpc.outputs.private_subnet_ids),
+      SECURITY_GROUP     = data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_fargate_security_group_id,
+      REGION             = var.aws_region,
       RDS_PROXY_ENDPOINT = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
-      LOG_LEVEL = "info",
+      LOG_LEVEL          = "info",
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -27,9 +27,9 @@ output "identity_pool_id" {
 }
 
 output "manifest_table_arn" {
-  value =aws_dynamodb_table.manifest_dynamo_table.arn
+  value = aws_dynamodb_table.manifest_dynamo_table.arn
 }
 
 output "manifest_table_name" {
-  value =aws_dynamodb_table.manifest_dynamo_table.name
+  value = aws_dynamodb_table.manifest_dynamo_table.name
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -7,13 +7,13 @@ resource "aws_s3_bucket" "uploads_s3_bucket" {
   }
 
   tags = merge(
-  local.common_tags,
-  {
-    "Name"         = "${var.environment_name}-uploads-v2-s3-bucket-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "name"         = "${var.environment_name}-uploads-v2-s3-bucket-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "service_name" = "upload-service-v2"
-    "tier"         = "s3"
-  },
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-uploads-v2-s3-bucket-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-uploads-v2-s3-bucket-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = "upload-service-v2"
+      "tier"         = "s3"
+    },
   )
 }
 
@@ -53,8 +53,8 @@ resource "aws_s3_bucket_notification" "uploads_s3_notification" {
   bucket = aws_s3_bucket.uploads_s3_bucket.bucket
 
   queue {
-    queue_arn     = aws_sqs_queue.upload_trigger_queue.arn
-    events        = ["s3:ObjectCreated:*"]
+    queue_arn = aws_sqs_queue.upload_trigger_queue.arn
+    events    = ["s3:ObjectCreated:*"]
   }
 }
 
@@ -68,13 +68,13 @@ resource "aws_s3_bucket" "manifest_archive_bucket" {
   }
 
   tags = merge(
-  local.common_tags,
-  {
-    "Name"         = "${var.environment_name}-uploads-v2-manifest-archive-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "name"         = "${var.environment_name}-uploads-v2-manifest-archive-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-    "service_name" = "upload-service-v2"
-    "tier"         = "s3"
-  },
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-uploads-v2-manifest-archive-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-uploads-v2-manifest-archive-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = "upload-service-v2"
+      "tier"         = "s3"
+    },
   )
 }
 

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,11 +1,11 @@
 # Upload Bucket Trigger Queue
 
 resource "aws_sqs_queue" "upload_trigger_queue" {
-  name                       = "${var.environment_name}-upload_trigger-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  delay_seconds              = 1
-  max_message_size           = 262144
-  message_retention_seconds  = 86400
-#  receive_wait_time_seconds  = 10
+  name                      = "${var.environment_name}-upload_trigger-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  delay_seconds             = 1
+  max_message_size          = 262144
+  message_retention_seconds = 86400
+  #  receive_wait_time_seconds  = 10
   visibility_timeout_seconds = 300
   redrive_policy             = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.upload_trigger_deadletter_queue.arn}\",\"maxReceiveCount\":3}"
 }
@@ -20,11 +20,11 @@ resource "aws_sqs_queue" "upload_trigger_deadletter_queue" {
 
 # Mapping SQS Source to Lambda Function
 resource "aws_lambda_event_source_mapping" "upload_source_mapping" {
-  event_source_arn = aws_sqs_queue.upload_trigger_queue.arn
-  function_name    = aws_lambda_function.upload_lambda.arn
-  batch_size = 25
+  event_source_arn                   = aws_sqs_queue.upload_trigger_queue.arn
+  function_name                      = aws_lambda_function.upload_lambda.arn
+  batch_size                         = 25
   maximum_batching_window_in_seconds = 5
-  function_response_types = ["ReportBatchItemFailures"]
+  function_response_types            = ["ReportBatchItemFailures"]
 }
 
 # Grant SNS to post to SQS queue
@@ -69,10 +69,10 @@ POLICY
 ## IMPORTED QUEUE ##
 ####################
 resource "aws_sqs_queue" "imported_file_queue" {
-  name                       = "${var.environment_name}-imported-file-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  delay_seconds              = 1
-  max_message_size           = 262144
-  message_retention_seconds  = 86400
+  name                      = "${var.environment_name}-imported-file-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  delay_seconds             = 1
+  max_message_size          = 262144
+  message_retention_seconds = 86400
   #  receive_wait_time_seconds  = 10
   visibility_timeout_seconds = 300
   redrive_policy             = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.imported_file_deadletter_queue.arn}\",\"maxReceiveCount\":3}"
@@ -89,9 +89,9 @@ resource "aws_sqs_queue" "imported_file_deadletter_queue" {
 
 # Mapping SQS Source to Lambda Function
 resource "aws_lambda_event_source_mapping" "imported_file_mapping" {
-  event_source_arn = aws_sqs_queue.imported_file_queue.arn
-  function_name    = aws_lambda_function.fargate_trigger_lambda.function_name
-  batch_size = 25
+  event_source_arn                   = aws_sqs_queue.imported_file_queue.arn
+  function_name                      = aws_lambda_function.fargate_trigger_lambda.function_name
+  batch_size                         = 25
   maximum_batching_window_in_seconds = 300
 }
 

--- a/terraform/upload-service.yml
+++ b/terraform/upload-service.yml
@@ -315,6 +315,93 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
+  /manifest/storage-credentials:
+    post:
+      summary: Get temporary S3 credentials for direct-to-storage upload
+      description: |
+        Returns temporary AWS credentials scoped to upload files directly to
+        the manifest's destination storage bucket under the
+        O{orgId}/D{datasetId}/{manifestId}/* prefix. Agents use these
+        credentials to skip the legacy upload-bucket staging hop.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/manifest-service'
+      operationId: getStorageCredentials
+      security:
+        - token_dataset_auth: [ ]
+      tags:
+        - Upload
+      parameters:
+        - in: query
+          name: dataset_id
+          schema:
+            type: string
+          required: true
+          description: dataset node id
+      requestBody:
+        description: Manifest node ID to scope credentials to
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - manifestNodeId
+              properties:
+                manifestNodeId:
+                  type: string
+                  description: The manifest node ID returned from POST /manifest
+      responses:
+        '200':
+          description: Temporary AWS credentials for direct-to-storage upload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/storageCredentialsResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /manifest/files/finalize:
+    post:
+      summary: Finalize a batch of files uploaded direct-to-storage
+      description: |
+        Completes the two-phase upload for files the agent has already PUT
+        directly to the storage bucket. The server verifies each object,
+        creates Postgres package/file rows, and marks the manifest file
+        Finalized. Idempotent per uploadId. Max 500 files per call.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/manifest-service'
+      operationId: finalizeManifestFiles
+      security:
+        - token_dataset_auth: [ ]
+      tags:
+        - Upload
+      parameters:
+        - in: query
+          name: dataset_id
+          schema:
+            type: string
+          required: true
+          description: dataset node id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/finalizeFilesRequest'
+      responses:
+        '200':
+          description: Per-file finalize results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/finalizeFilesResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
   /manifest/archive:
     post:
       x-amazon-apigateway-integration:
@@ -585,6 +672,74 @@ components:
         region:
           type: string
           description: AWS region of the upload bucket
+    storageCredentialsResponse:
+      type: object
+      properties:
+        accessKeyId:
+          type: string
+        secretAccessKey:
+          type: string
+        sessionToken:
+          type: string
+        expiration:
+          type: string
+          format: date-time
+        bucket:
+          type: string
+          description: Destination storage bucket for this manifest.
+        keyPrefix:
+          type: string
+          description: Object-key prefix the credentials are scoped to (O{orgId}/D{datasetId}/{manifestId}).
+        region:
+          type: string
+    finalizeFilesRequest:
+      type: object
+      required:
+        - manifestNodeId
+        - files
+      properties:
+        manifestNodeId:
+          type: string
+          format: uuid
+        files:
+          type: array
+          minItems: 1
+          maxItems: 500
+          items:
+            type: object
+            required:
+              - uploadId
+              - size
+              - sha256
+            properties:
+              uploadId:
+                type: string
+                format: uuid
+              size:
+                type: integer
+                format: int64
+                minimum: 1
+              sha256:
+                type: string
+                description: Base64-encoded SHA256 checksum returned by S3 multipart upload (the ChecksumSHA256 field of manager.UploadOutput). Server verifies this matches the value HEAD returns.
+    finalizeFilesResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              uploadId:
+                type: string
+              status:
+                type: string
+                enum:
+                  - finalized
+                  - failed
+              error:
+                type: string
+                description: Present when status = failed.
     addFilesResponse:
       type: object
       description: Response for addFiles endpoint.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -77,6 +77,6 @@ locals {
     environment_name = var.environment_name
   }
 
-  cors_allowed_origins  = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
+  cors_allowed_origins = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
 
 }


### PR DESCRIPTION
Adds a new upload path that lets authenticated agents PUT files directly to the destination storage bucket under O{org}/D{ds}/{manifest}/{upload}, skipping the upload-bucket staging hop and Fargate move task. Legacy upload-bucket -> SQS -> upload-lambda -> SNS -> Fargate pipeline is preserved byte-for-byte for old agents and cross-account clients.

New endpoints on the service lambda:
  POST /manifest/storage-credentials - mints STS creds scoped to the
    manifest's destination bucket + prefix via a new
    storage_credentials_role that attaches the account-service dynamic
    storage-write managed policy plus the static storage bucket list.
  POST /manifest/files/finalize - two-phase upload completion.
    Batches of up to 500 files. Verifies each object via HEAD
    (size + SHA256 from S3's ChecksumAlgorithm), then synthesizes
    SQS/S3 events and invokes the upload-lambda synchronously.

Upload lambda recognizes O-prefixed keys as direct-to-storage, writes Postgres files rows pointing at the final storage location on first insert, and skips the SNS publish that would otherwise trigger Fargate. Regex kept unanchored so nested keys from cross-account clients still match.

Security hardening on both credential-issuing endpoints:
  - strict UUID validation on manifestNodeId before session-policy construction (defense in depth against JSON injection into the inline AssumeRole policy)
  - sanitized error responses (detail to CloudWatch only)
  - per-file input validation on finalize (UUID uploadId, size > 0, required SHA256 checksum match against HEAD)
  - finalize rejects uploadIds that don't belong to the manifest