### PR TITLE
Attach account-service storage_read managed policy to service lambda

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -942,3 +942,11 @@ resource "aws_iam_role_policy_attachment" "fargate_storage_bucket_write" {
   role       = aws_iam_role.fargate_task_iam_role.name
   policy_arn = data.terraform_remote_state.account_service.outputs.storage_write_policy_arn
 }
+
+# Service lambda needs read on dynamic workspace storage buckets for the
+# finalize endpoint's HEAD verification. Managed policy is refreshed by
+# account-service whenever storage nodes are added/removed.
+resource "aws_iam_role_policy_attachment" "service_lambda_storage_bucket_read" {
+  role       = aws_iam_role.upload_service_v2_lambda_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_read_policy_arn
+}


### PR DESCRIPTION
The finalize endpoint HEADs objects in the destination storage bucket to verify size + SHA256 before creating Postgres rows. Previously the service lambda role only had S3 perms on the upload and archive buckets, so HEADs against storage buckets returned 403, and finalize marked every file as 'object not found'.

Attach account-service's storage_read_policy_arn managed policy (same pattern as the existing fargate_storage_bucket_write). The policy's bucket list is rebuilt by account-service whenever storage nodes are added/modified/removed, so this auto-covers every workspace bucket without maintaining a static list here.