### PR TITLE
Reconcile/archiver/upload: progress logging, throttle fix, data-loss bug fixes

### DIFF
--- a/lambda/archive-sweeper/handler/handler.go
+++ b/lambda/archive-sweeper/handler/handler.go
@@ -34,7 +34,7 @@ var (
 
 const (
 	defaultMaxAgeDays       = 90
-	defaultMaxInvokesPerRun = 500
+	defaultMaxInvokesPerRun = 50
 )
 
 func init() {

--- a/lambda/archiver/handler/handler.go
+++ b/lambda/archiver/handler/handler.go
@@ -59,9 +59,13 @@ func ManifestHandler(event ArchiveEvent) error {
 
 	ctx := context.Background()
 	csvFileName := fmt.Sprintf("manifest_archive_%s.csv", event.ManifestId)
-	_, err := store.writeCSVFile(ctx, csvFileName, event.ManifestId)
+	if _, err := store.writeCSVFile(ctx, csvFileName, event.ManifestId); err != nil {
+		log.WithError(err).WithField("manifest_id", event.ManifestId).
+			Error("writeCSVFile failed; aborting archive so Lambda async retry can re-run")
+		return err
+	}
 
-	_, err = store.writeManifestToS3(ctx, csvFileName, event.OrganizationId, event.DatasetId)
+	_, err := store.writeManifestToS3(ctx, csvFileName, event.OrganizationId, event.DatasetId)
 	if err != nil {
 		return err
 	}

--- a/lambda/archiver/handler/store.go
+++ b/lambda/archiver/handler/store.go
@@ -37,67 +37,63 @@ func NewArchiverStore(dy *dynamodb.Client, s3Client *s3.Client, fileTableName st
 	}
 }
 
-// writeCSVFile writes manifestFiles to a CSV file in the /tmp/ folder
+// writeCSVFile writes manifestFiles to a CSV file in the /tmp/ folder.
+// Any error from GetFilesPaginated is returned to the caller — a throttle
+// or other query failure must abort the archive, not produce a 0-byte CSV
+// that then gets paired with a row-delete (silent data loss).
 func (s *ArchiverStore) writeCSVFile(ctx context.Context, fileName string, manifestId string) (string, error) {
 	file, err := os.Create(fmt.Sprintf("/tmp/%s", fileName))
-	defer file.Close()
 	if err != nil {
 		log.WithFields(
 			log.Fields{
 				"manifest_id": manifestId,
 			}).Error("unable to create archive CSV file")
-		return file.Name(), err
-
+		return "", err
 	}
+	defer file.Close()
 
 	w := csv.NewWriter(file)
 	defer w.Flush()
 
-	var files []dydbModels.ManifestFileTable
 	pageSize := int32(200)
 
 	files, lastEntry, err := s.dy.GetFilesPaginated(ctx, s.fileTableName, manifestId, sql.NullString{Valid: false}, pageSize, nil)
+	if err != nil {
+		return file.Name(), fmt.Errorf("GetFilesPaginated: %w", err)
+	}
 
-	if len(files) > 0 {
-
-		// Write Headers
-		firstFile := files[0]
-		headers := firstFile.GetHeaders()
-		err = w.Write(headers)
-		if err != nil {
-			return file.Name(), err
-		}
-
-		// Write Files
-		for _, f := range files {
-			rowSlice := f.ToSlice()
-			err := w.Write(rowSlice)
-			if err != nil {
-				return file.Name(), err
-			}
-		}
-
-		// If there are more entries, get next page and write files.
-		for len(lastEntry) != 0 {
-			files, lastEntry, err = s.dy.GetFilesPaginated(ctx, s.fileTableName, manifestId, sql.NullString{Valid: false}, pageSize, lastEntry)
-
-			for _, f := range files {
-				rowSlice := f.ToSlice()
-				err := w.Write(rowSlice)
-				if err != nil {
-					return file.Name(), err
-				}
-			}
-		}
-	} else {
+	if len(files) == 0 {
 		log.WithFields(
 			log.Fields{
 				"manifest_id": manifestId,
 			}).Info("Archived manifest has no files.")
+		return file.Name(), nil
+	}
+
+	// Write headers from the first file's schema.
+	if err := w.Write(files[0].GetHeaders()); err != nil {
+		return file.Name(), err
+	}
+
+	for _, f := range files {
+		if err := w.Write(f.ToSlice()); err != nil {
+			return file.Name(), err
+		}
+	}
+
+	for len(lastEntry) != 0 {
+		files, lastEntry, err = s.dy.GetFilesPaginated(ctx, s.fileTableName, manifestId, sql.NullString{Valid: false}, pageSize, lastEntry)
+		if err != nil {
+			return file.Name(), fmt.Errorf("GetFilesPaginated page: %w", err)
+		}
+		for _, f := range files {
+			if err := w.Write(f.ToSlice()); err != nil {
+				return file.Name(), err
+			}
+		}
 	}
 
 	return file.Name(), nil
-
 }
 
 // writeManifestToS3 takes a CSV file and stores it in the manifest-archive bucket

--- a/lambda/reconcile/handler/handler.go
+++ b/lambda/reconcile/handler/handler.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -144,6 +145,37 @@ func Handle(ctx context.Context, p Payload) (Result, error) {
 	var result Result
 	result.DryRun = p.DryRun
 	result.PerManifest = make(map[string]ManifestStats)
+
+	// Progress ticker: logs running totals every 10s. Without this, a 600s
+	// timeout produces a final summary that never fires, and CloudWatch
+	// shows only sporadic warnings. The per-file DynamoDB commits already
+	// preserve partial progress across timeouts — this is just visibility.
+	progressDone := make(chan struct{})
+	go func() {
+		start := time.Now()
+		tick := time.NewTicker(10 * time.Second)
+		defer tick.Stop()
+		for {
+			select {
+			case <-progressDone:
+				return
+			case <-tick.C:
+				scanned, recovered, missing, enqFailed, errs := store.snapshot(&result)
+				elapsed := time.Since(start).Seconds()
+				rate := float64(scanned) / elapsed
+				log.WithFields(log.Fields{
+					"scanned":        scanned,
+					"recovered":      recovered,
+					"missing":        missing,
+					"enqueue_failed": enqFailed,
+					"errors":         errs,
+					"elapsed_sec":    int(elapsed),
+					"rate_per_sec":   int(rate),
+				}).Info("reconcile progress")
+			}
+		}
+	}()
+	defer close(progressDone)
 
 	if p.ManifestNodeID != "" {
 		if err := store.reconcileManifest(ctx, p.ManifestNodeID, p.DryRun, concurrency, &result); err != nil {

--- a/lambda/reconcile/handler/store.go
+++ b/lambda/reconcile/handler/store.go
@@ -34,6 +34,11 @@ type store struct {
 	manifestFileTable     string
 	uploadTriggerQueueURL string
 	defaultStorageBucket  string
+
+	// mu serializes Result/PerManifest updates across the worker pool.
+	// Lives on the store so the Handle goroutine can safely snapshot
+	// counters for periodic progress logging.
+	mu sync.Mutex
 }
 
 // resolvedManifest is what we need to reconstruct an S3 key and decide the
@@ -76,7 +81,6 @@ func (s *store) reconcileManifest(ctx context.Context, manifestID string, dryRun
 	if err != nil {
 		return err
 	}
-	var mu sync.Mutex
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
@@ -86,14 +90,14 @@ func (s *store) reconcileManifest(ctx context.Context, manifestID string, dryRun
 		go func(uid string, sz int64) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			s.reconcileFile(ctx, resolved, uid, sz, dryRun, &mu, result)
+			s.reconcileFile(ctx, resolved, uid, sz, dryRun, result)
 		}(uploadID, size)
 	})
 	wg.Wait()
 
-	mu.Lock()
+	s.mu.Lock()
 	result.ManifestsScanned = 1
-	mu.Unlock()
+	s.mu.Unlock()
 	return err
 }
 
@@ -107,7 +111,6 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 	cutoff := time.Now().Add(-time.Duration(gracePeriodHours) * time.Hour).Unix()
 	cache := make(map[string]*resolvedManifest)
 
-	var mu sync.Mutex
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
@@ -140,9 +143,9 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 				r, err := s.resolveManifest(ctx, manifestID)
 				if err != nil {
 					log.WithError(err).WithField("manifest_id", manifestID).Warn("resolve failed, skipping manifest")
-					mu.Lock()
+					s.mu.Lock()
 					result.Errors = append(result.Errors, err.Error())
-					mu.Unlock()
+					s.mu.Unlock()
 					cache[manifestID] = nil // skip subsequent files for this manifest
 					continue
 				}
@@ -164,7 +167,7 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 			go func(res *resolvedManifest, uid string) {
 				defer wg.Done()
 				defer func() { <-sem }()
-				s.reconcileFile(ctx, res, uid, 0, dryRun, &mu, result)
+				s.reconcileFile(ctx, res, uid, 0, dryRun, result)
 			}(resolved, uploadID)
 		}
 	}
@@ -177,9 +180,9 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 			scanned++
 		}
 	}
-	mu.Lock()
+	s.mu.Lock()
 	result.ManifestsScanned = scanned
-	mu.Unlock()
+	s.mu.Unlock()
 	return nil
 }
 
@@ -215,7 +218,7 @@ func (s *store) forEachRegisteredFile(ctx context.Context, manifestID string, fn
 
 // reconcileFile does the per-file recovery: HEAD the storage key, enqueue if
 // present, otherwise count as missing. Safe to call concurrently — all
-// Result/PerManifest updates are serialized through mu. I/O (HEAD,
+// Result/PerManifest updates are serialized through s.mu. I/O (HEAD,
 // UpdateItem, SendMessage) runs outside the mutex.
 func (s *store) reconcileFile(
 	ctx context.Context,
@@ -223,11 +226,10 @@ func (s *store) reconcileFile(
 	uploadID string,
 	expectedSize int64,
 	dryRun bool,
-	mu *sync.Mutex,
 	result *Result,
 ) {
 	manifestID := resolved.manifest.ManifestId
-	bumpScanned(mu, result, manifestID)
+	s.bumpScanned(result, manifestID)
 
 	key := fmt.Sprintf("%s/%s", resolved.keyPrefix, uploadID)
 	head, err := s.s3.HeadObject(ctx, &s3.HeadObjectInput{
@@ -243,10 +245,10 @@ func (s *store) reconcileFile(
 		// permission) are transient — leave Registered so the next
 		// scheduled run retries.
 		if isS3NotFound(err) {
-			bumpMissing(mu, result, manifestID)
+			s.bumpMissing(result, manifestID)
 			if !dryRun {
 				if updErr := s.markFailedOrphan(ctx, manifestID, uploadID); updErr != nil {
-					appendError(mu, result, fmt.Sprintf("markFailedOrphan %s: %v", uploadID, updErr))
+					s.appendError(result, fmt.Sprintf("markFailedOrphan %s: %v", uploadID, updErr))
 					log.WithError(updErr).WithFields(log.Fields{
 						"manifest_id": manifestID,
 						"upload_id":   uploadID,
@@ -254,7 +256,7 @@ func (s *store) reconcileFile(
 				}
 			}
 		} else {
-			appendError(mu, result, fmt.Sprintf("HEAD %s: %v", uploadID, err))
+			s.appendError(result, fmt.Sprintf("HEAD %s: %v", uploadID, err))
 			log.WithError(err).WithFields(log.Fields{
 				"manifest_id": manifestID,
 				"upload_id":   uploadID,
@@ -265,7 +267,7 @@ func (s *store) reconcileFile(
 	}
 
 	if dryRun {
-		bumpRecovered(mu, result, manifestID)
+		s.bumpRecovered(result, manifestID)
 		log.WithFields(log.Fields{
 			"manifest_id": manifestID,
 			"upload_id":   uploadID,
@@ -276,50 +278,59 @@ func (s *store) reconcileFile(
 	}
 
 	if err := s.enqueueRecovery(ctx, resolved.storageBucket, key, aws.ToInt64(head.ContentLength)); err != nil {
-		mu.Lock()
+		s.mu.Lock()
 		result.EnqueueFailed++
 		result.Errors = append(result.Errors, fmt.Sprintf("enqueue %s: %v", uploadID, err))
-		mu.Unlock()
+		s.mu.Unlock()
 		log.WithError(err).WithFields(log.Fields{
 			"manifest_id": manifestID,
 			"upload_id":   uploadID,
 		}).Warn("enqueue failed")
 		return
 	}
-	bumpRecovered(mu, result, manifestID)
+	s.bumpRecovered(result, manifestID)
 }
 
-func bumpScanned(mu *sync.Mutex, r *Result, manifestID string) {
-	mu.Lock()
-	defer mu.Unlock()
+func (s *store) bumpScanned(r *Result, manifestID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	r.FilesScanned++
 	stats := r.PerManifest[manifestID]
 	stats.FilesScanned++
 	r.PerManifest[manifestID] = stats
 }
 
-func bumpMissing(mu *sync.Mutex, r *Result, manifestID string) {
-	mu.Lock()
-	defer mu.Unlock()
+func (s *store) bumpMissing(r *Result, manifestID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	r.Missing++
 	stats := r.PerManifest[manifestID]
 	stats.Missing++
 	r.PerManifest[manifestID] = stats
 }
 
-func bumpRecovered(mu *sync.Mutex, r *Result, manifestID string) {
-	mu.Lock()
-	defer mu.Unlock()
+func (s *store) bumpRecovered(r *Result, manifestID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	r.Recovered++
 	stats := r.PerManifest[manifestID]
 	stats.Recovered++
 	r.PerManifest[manifestID] = stats
 }
 
-func appendError(mu *sync.Mutex, r *Result, msg string) {
-	mu.Lock()
-	defer mu.Unlock()
+func (s *store) appendError(r *Result, msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	r.Errors = append(r.Errors, msg)
+}
+
+// snapshot returns a copy of the counters under mu. Intended for the
+// progress-logging goroutine; PerManifest/Errors are deliberately omitted to
+// keep the snapshot small.
+func (s *store) snapshot(r *Result) (scanned, recovered, missing, enqueueFailed, errs int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return r.FilesScanned, r.Recovered, r.Missing, r.EnqueueFailed, len(r.Errors)
 }
 
 // markFailedOrphan flips a Registered row to FailedOrphan status. The

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -250,10 +250,7 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 		return response, nil
 	})
 	if err != nil {
-		if err != nil {
-			contextLogger.Error("Unable to create Packages and/or Files. ", err)
-			return err
-		}
+		contextLogger.Error("Unable to create Packages and/or Files. ", err)
 		return err
 	}
 
@@ -264,6 +261,10 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 
 	// 4. Update storage for Packages, Dataset and Organization.
 	storageMap, err := s.createStorageUpdateMap(ctx, result)
+	if err != nil {
+		contextLogger.WithError(err).Error("Unable to compute storage update map.")
+		return err
+	}
 	_, err = s.execTx(ctx, func(qtx *UploadPgQueries) (interface{}, error) {
 
 		err = qtx.IncrementOrganizationStorage(ctx, int64(orgId), storageMap.total)

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -195,9 +195,14 @@ resource "aws_cloudwatch_event_target" "archive_sweeper_target" {
   rule      = aws_cloudwatch_event_rule.archive_sweeper_schedule.name
   target_id = "archive-sweeper-lambda"
   arn       = aws_lambda_function.archive_sweeper_lambda.arn
+  # maxInvokesPerRun kept low so parallel archive-lambdas don't saturate the
+  # manifest_files GSI write-capacity. 500 was observed to trigger
+  # ThrottlingException on StatusIndex until DynamoDB auto-scaled. The daily
+  # run will drain any backlog across consecutive days rather than in a single
+  # burst.
   input = jsonencode({
     maxAgeDays       = 90
-    maxInvokesPerRun = 500
+    maxInvokesPerRun = 50
   })
 }
 


### PR DESCRIPTION
Bundle of fixes surfaced while manually draining the dev reconcile backlog. Each commit is independent.

## Commits

1. **Log reconcile progress every 10s** (`208877d`)
   Reconcile invocations were hitting the 600s Lambda timeout with no final summary (emits only at function exit). CloudWatch showed only sparse warnings — flying blind. Adds a ticker goroutine in `Handle` that logs running totals (scanned / recovered / missing / enqueue_failed / errors / elapsed / rate_per_sec) every 10s. Ticker reads counters via a new `store.snapshot` method under the existing worker-pool mutex (moved onto the store field).

2. **Lower archive-sweeper default `maxInvokesPerRun` from 500 to 50** (`7e86da2`)
   A manual sweep of 500 parallel archive-lambda invocations saturated the `manifest_files` `StatusIndex` GSI write-capacity and triggered `ThrottlingException` until DynamoDB auto-scaled. 50 keeps the burst within headroom; the daily scheduled run drains any backlog across days instead of a single stampede. Updated both the Go default and the EventBridge schedule input.

3. **Fix archiver silently swallowing query errors into 0-byte CSVs** (`7318664`)
   `writeCSVFile` ignored the `err` from `GetFilesPaginated`, so a DynamoDB throttle on the query step produced a 0-byte CSV; that CSV was then uploaded to S3 and paired with `UpdateManifestStatus → Archived` + `removeManifestFiles`. If the query step failed but the delete step succeeded, a manifest was archived with an empty CSV and its file metadata was lost with no archive record. Now any query error aborts the archive and bubbles up, so Lambda's async-retry layer re-runs against the still-unflipped manifest. Also fixed `handler.go` discarding `writeCSVFile`'s error by overwriting it with `writeManifestToS3`'s return.

4. **Upload lambda: propagate `createStorageUpdateMap` error** (`7bb723d`)
   Same err-overwrite pattern: `createStorageUpdateMap`'s error was overwritten one line later by `execTx`, so a transient Postgres failure on `GetPackageAncestorIds` was swallowed and `execTx` ran with `storageMap=nil` — deferring failure into a nil-deref panic instead of surfacing a clean error. Also removed a dead duplicated `if err != nil` block (likely a bad merge).

## Forensic check

Audited all 111 of today's 0-byte CSVs (after the throttle burst that surfaced commit 3's bug): 110 have no objects in the storage bucket, 1 has 21 orphaned objects from 2023-03-14 — pre-dating today's burst. No data loss from this session; commit 3 prevents recurrence.

## Test plan

- [x] `go build ./...` in `lambda/reconcile`, `lambda/archive-sweeper`, `lambda/archiver`, `lambda/upload` — all clean.
- [x] `VERSION=test-local make package` builds and zips all six lambdas.
- [ ] Deploy to dev; manually invoke reconcile and confirm `"reconcile progress"` log lines every 10s.
- [ ] Confirm EventBridge-scheduled archive-sweeper fires with `maxInvokesPerRun=50` and no GSI throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)