### PR TITLE
Grant reconcile lambda dynamodb:UpdateItem on manifest_files

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1034,6 +1034,20 @@ data "aws_iam_policy_document" "reconcile_lambda_policy_document" {
     ]
   }
 
+  # UpdateItem on manifest_files so markFailedOrphan can flip
+  # confirmed-missing rows from Registered -> FailedOrphan (terminal state
+  # that removes them from the StatusIndex=Registered scan on future runs).
+  statement {
+    sid    = "ReconcileMarkFailedOrphan"
+    effect = "Allow"
+    actions = [
+      "dynamodb:UpdateItem",
+    ]
+    resources = [
+      aws_dynamodb_table.manifest_files_dynamo_table.arn,
+    ]
+  }
+
   # Postgres connection via RDS Proxy (for storage-bucket resolution).
   statement {
     sid    = "ReconcileRDS"


### PR DESCRIPTION
## Summary
- First manual invocation of the reconcile lambda against dev revealed an IAM gap: `markFailedOrphan` was returning `AccessDeniedException` on every HEAD-404 file, so rows stayed stuck as `Registered` forever and each scheduled run re-scanned the same backlog.
- Adds a new IAM statement granting `dynamodb:UpdateItem` on the `manifest_files` table (not the GSIs — UpdateItem only writes to the base table).

Observed in CloudWatch:
```
AccessDeniedException: User: ...reconcile-lambda-role... is not authorized to
perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:...:table/dev-manifest-files-table-use1
```

## Test plan
- [ ] Deploy; re-invoke reconcile against dev with `{"gracePeriodHours":24,"concurrency":32}`.
- [ ] Confirm `"reconcile progress"` log lines show `errors ≈ 0` (previously errors ≈ missing because every markFailedOrphan failed).
- [ ] Next run's `missing` count should drop to near-zero (previous run's FailedOrphan flips remove those rows from the Registered scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)