### PR TITLE
Drop SQS batching window 5s → 1s for upload_trigger_queue

### DIFF
--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -20,10 +20,16 @@ resource "aws_sqs_queue" "upload_trigger_deadletter_queue" {
 
 # Mapping SQS Source to Lambda Function
 resource "aws_lambda_event_source_mapping" "upload_source_mapping" {
-  event_source_arn                   = aws_sqs_queue.upload_trigger_queue.arn
-  function_name                      = aws_lambda_function.upload_lambda.arn
-  batch_size                         = 25
-  maximum_batching_window_in_seconds = 5
+  event_source_arn = aws_sqs_queue.upload_trigger_queue.arn
+  function_name    = aws_lambda_function.upload_lambda.arn
+  batch_size       = 25
+  # 1s (down from 5s): the window only matters when messages arrive
+  # slower than 25/batch_size — bulk uploads hit the batch cap first
+  # and invoke immediately regardless. For the small-drop case (trickle
+  # from eager client-side finalize) this shaves ~4s off the observed
+  # finalize->Pusher latency. Concurrency brake is still
+  # reserved_concurrent_executions=100 on the upload lambda.
+  maximum_batching_window_in_seconds = 1
   function_response_types            = ["ReportBatchItemFailures"]
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #87. With the client now eager-flushing small finalize batches every ~1s (pennsieve-app `FINALIZE_FLUSH_MS`), the SQS `maximum_batching_window_in_seconds` is the next compressible lever on end-to-end finalize→Pusher latency.

## Change

`terraform/sqs.tf` — `upload_source_mapping.maximum_batching_window_in_seconds`: `5` → `1`. That's it.

`batch_size` stays at 25. For bulk uploads, the batch cap fires before the window elapses anyway, so this change only compresses the small-drop trickle case. Concurrency brake remains `reserved_concurrent_executions=100` on the upload lambda.

## Measured baseline

Manifest `5dd24b4d` (12 files) after the #87 changes took 12s from drop → first package visible. Expected ~8s after this change.

## Risk

Slightly more lambda invocations on small batches (up to 5× during trickle periods). RDS concurrency cap and the memory-bumped upload lambda absorb this fine. Monitor RDS proxy connection pressure in dev after deploy; if it shows up as an issue, bumping back to 2s is a one-line revert.

## Test plan

- [ ] Deploy to dev (auto on merge)
- [ ] Re-run a small drop (3–5 files) and measure drop → first-package delta; expect 8–10s
- [ ] Watch CloudWatch invocation count and RDS proxy metrics for any anomaly

🤖 Generated with [Claude Code](https://claude.com/claude-code)