### PR TITLE
archive-sweeper: query ManifestStatusIndex instead of full Scan

### DIFF
--- a/lambda/archive-sweeper/handler/sweeper.go
+++ b/lambda/archive-sweeper/handler/sweeper.go
@@ -39,13 +39,24 @@ type archiveEvent struct {
 	RemoveFromDB   bool   `json:"remove_from_db"`
 }
 
-// run scans manifest_table with a FilterExpression bounding by age and
-// Status, then invokes archive_lambda async for each eligible manifest up
-// to maxInvokesPerRun.
+// nonArchivedStatuses enumerates every manifest.Status value except
+// Archived. The sweeper Queries each one against ManifestStatusIndex to
+// build the eligible-for-archival set. New non-Archived statuses MUST be
+// added here or they will silently never get archived.
+var nonArchivedStatuses = []manifest.Status{
+	manifest.Initiated,
+	manifest.Uploading,
+	manifest.Completed,
+	manifest.Cancelled,
+}
+
+// run queries ManifestStatusIndex once per non-Archived status, picking up
+// rows older than MaxAgeDays, and invokes archive_lambda async for each
+// eligible manifest up to maxInvokesPerRun.
 //
-// Uses Scan (not Query) because the manifest table has no index on
-// DateCreated/Status. The table is small (one row per manifest) relative to
-// manifest_files, so a full scan is acceptable for a daily job.
+// Replaces the previous Scan-with-FilterExpression approach. With the GSI
+// on (Status, DateCreated), each Query reads only the rows that match — no
+// per-row filter overhead, and no read charge for archived items.
 func (s *sweeper) run(ctx context.Context) (Result, error) {
 	res := Result{
 		DryRun:     s.dryRun,
@@ -54,25 +65,42 @@ func (s *sweeper) run(ctx context.Context) (Result, error) {
 
 	cutoff := time.Now().Add(-time.Duration(s.maxAgeDays) * 24 * time.Hour).Unix()
 
-	p := dynamodb.NewScanPaginator(s.dy, &dynamodb.ScanInput{
-		TableName: aws.String(s.manifestTable),
-		FilterExpression: aws.String(
-			"DateCreated < :cutoff AND #s <> :archived",
-		),
+	for _, status := range nonArchivedStatuses {
+		done, err := s.runForStatus(ctx, status, cutoff, &res)
+		if err != nil {
+			return res, err
+		}
+		if done {
+			return res, nil
+		}
+	}
+
+	return res, nil
+}
+
+// runForStatus pages through ManifestStatusIndex for a single status,
+// invoking archive_lambda for each eligible row. Returns done=true if the
+// caller should stop (MaxInvokesPerRun reached); err is set only on
+// unrecoverable Query failures.
+func (s *sweeper) runForStatus(ctx context.Context, status manifest.Status, cutoff int64, res *Result) (bool, error) {
+	p := dynamodb.NewQueryPaginator(s.dy, &dynamodb.QueryInput{
+		TableName:              aws.String(s.manifestTable),
+		IndexName:              aws.String("ManifestStatusIndex"),
+		KeyConditionExpression: aws.String("#s = :status AND DateCreated < :cutoff"),
 		ExpressionAttributeNames: map[string]string{
 			"#s": "Status",
 		},
 		ExpressionAttributeValues: map[string]dyTypes.AttributeValue{
-			":cutoff":   &dyTypes.AttributeValueMemberN{Value: fmt.Sprintf("%d", cutoff)},
-			":archived": &dyTypes.AttributeValueMemberS{Value: manifest.Archived.String()},
+			":status": &dyTypes.AttributeValueMemberS{Value: status.String()},
+			":cutoff": &dyTypes.AttributeValueMemberN{Value: fmt.Sprintf("%d", cutoff)},
 		},
 	})
 
 	for p.HasMorePages() {
 		page, err := p.NextPage(ctx)
 		if err != nil {
-			res.Errors = append(res.Errors, fmt.Sprintf("scan: %v", err))
-			return res, err
+			res.Errors = append(res.Errors, fmt.Sprintf("query %s: %v", status.String(), err))
+			return false, err
 		}
 		res.ManifestsScanned += int(page.ScannedCount)
 
@@ -82,17 +110,19 @@ func (s *sweeper) run(ctx context.Context) (Result, error) {
 				res.Errors = append(res.Errors, fmt.Sprintf("unmarshal manifest: %v", err))
 				continue
 			}
+			// Status isn't projected (it's the index hash key, but
+			// UnmarshalMap won't see it from key-only context); restore it
+			// so downstream logging is accurate.
+			m.Status = status.String()
 			res.ManifestsEligible++
 
 			if res.InvokesAttempted >= s.maxInvokesPerRun {
-				// Leave the rest for the next scheduled run; bail out of the
-				// page (also stops paginator on next HasMorePages check).
 				log.WithFields(log.Fields{
-					"eligible":     res.ManifestsEligible,
-					"max_per_run":  s.maxInvokesPerRun,
-					"manifest_id":  m.ManifestId,
+					"eligible":    res.ManifestsEligible,
+					"max_per_run": s.maxInvokesPerRun,
+					"manifest_id": m.ManifestId,
 				}).Info("hit MaxInvokesPerRun; deferring remaining manifests to next run")
-				return res, nil
+				return true, nil
 			}
 
 			logger := log.WithFields(log.Fields{
@@ -121,7 +151,7 @@ func (s *sweeper) run(ctx context.Context) (Result, error) {
 		}
 	}
 
-	return res, nil
+	return false, nil
 }
 
 func (s *sweeper) invokeArchive(ctx context.Context, m dydb.ManifestTable) error {

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -19,11 +19,33 @@ resource "aws_dynamodb_table" "manifest_dynamo_table" {
     type = "S"
   }
 
+  attribute {
+    name = "Status"
+    type = "S"
+  }
+
+  attribute {
+    name = "DateCreated"
+    type = "N"
+  }
+
   global_secondary_index {
     name            = "DatasetManifestIndex"
     hash_key        = "DatasetNodeId"
     range_key       = "UserId"
     projection_type = "ALL"
+  }
+
+  // Used by the archive-sweeper to find old un-archived manifests via Query
+  // instead of a Scan-with-FilterExpression. Partitioned by Status so the
+  // sweeper queries each non-Archived status (Initiated, Uploading,
+  // Completed, Cancelled) for items older than MaxAgeDays.
+  global_secondary_index {
+    name               = "ManifestStatusIndex"
+    hash_key           = "Status"
+    range_key          = "DateCreated"
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["OrganizationId", "DatasetId"]
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## Summary
- Adds a GSI on `manifest_table` keyed on `(Status, DateCreated)` and rewrites the archive-sweeper to Query each non-Archived status (Initiated, Uploading, Completed, Cancelled) instead of doing a full-table Scan with FilterExpression.
- At current scale the cost saving is trivial (~$0.0002/day on 30k rows). The point is the access pattern: Scan + FilterExpression charges read capacity for every row including the 25k+ Archived ones we don't care about, and grows linearly with table size. Query against the GSI reads only the rows that match.
- No backfill, no migration, no `pennsieve-go-core` changes — every existing manifest already has a `Status` attribute, so DynamoDB rebuilds the GSI from existing items automatically when terraform applies.

## Why Status-GSI over a sparse "EligibleForArchive" attribute

A sparse-attribute GSI was the alternative. We picked the Status-GSI because:
- No model change in `pennsieve-go-core` and no `go.mod` dep bump.
- No one-shot backfill of existing manifests.
- `UpdateManifestStatus(Archived)` already moves the row to the Archived partition — no extra `REMOVE` needed on archive.

Tradeoffs the reviewer should confirm:
- The sweeper now hardcodes the non-Archived enum (`nonArchivedStatuses` in `sweeper.go`). **If a new non-Archived status is ever added to `manifest.Status`, it MUST be added to that slice or the sweeper will silently skip those manifests forever.** The comment on the slice flags this.
- Archived items live in the GSI on the Archived partition forever (sweeper never reads it, but it costs ~5 MB of GSI storage today; trivial).
- Hot partition skew: `Completed` will dominate writes since most manifests pass through it. Single GSI write/sec is well under the per-partition ceiling at our rate.

## Deploy order

1. **Apply terraform first.** DynamoDB rebuilds the GSI from existing items in the background. For `prod-manifest-table-use1` (5.3 MB, 30k rows) this should finish in minutes; check `aws dynamodb describe-table … --query "Table.GlobalSecondaryIndexes[?IndexName=='ManifestStatusIndex'].IndexStatus"` for `ACTIVE`. During the rebuild, queries against the new index return incomplete results — but the sweeper lambda still has the old Scan code at this point, so this is invisible to operations.
2. **Then deploy the lambda code** (this PR). At deploy time the sweeper switches to Query.

## Test plan

- [x] `go vet ./...` clean in `lambda/archive-sweeper`.
- [x] `go build ./...` clean.
- [ ] After GSI is `ACTIVE` in dev: invoke the sweeper with `dryRun: true` and confirm `manifestsEligible` matches the previous Scan-based count.
- [ ] After deploy in prod: watch the next 07:30 UTC run; expect `manifestsScanned` to drop sharply (we now only read items that match each status partition rather than the full table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)