### PR TITLE
finalize: allow 0-byte files

### DIFF
--- a/lambda/service/handler/finalize_files.go
+++ b/lambda/service/handler/finalize_files.go
@@ -105,13 +105,16 @@ func postFinalizeFilesRoute(request events.APIGatewayV2HTTPRequest, claims *auth
 	}
 	// Per-file input validation. Bad inputs fail the whole batch — we don't
 	// want to quietly drop malformed entries because the client may think they
-	// were accepted.
+	// were accepted. Size 0 is explicitly allowed: empty files (.gitkeep,
+	// __init__.py, BIDS placeholders, sentinel files) are legitimate content
+	// that S3 stores natively, and the HEAD-verification step below already
+	// enforces the agent-reported size matches what S3 received.
 	for i, f := range req.Files {
 		if !isValidUUID(f.UploadID) {
 			return errResp(400, fmt.Sprintf("files[%d].uploadId must be a UUID", i))
 		}
-		if f.Size <= 0 {
-			return errResp(400, fmt.Sprintf("files[%d].size must be > 0", i))
+		if f.Size < 0 {
+			return errResp(400, fmt.Sprintf("files[%d].size must be non-negative", i))
 		}
 		if f.SHA256 == "" {
 			return errResp(400, fmt.Sprintf("files[%d].sha256 is required", i))


### PR DESCRIPTION
## Summary
- Drop the `size > 0` check in `postFinalizeFilesRoute` that I added in 02fc5b0 as input-shape hardening
- Tighten to `size < 0` so impossible negatives still get a clear 400
- Surfaced when an agent upload of a `~/Desktop` folder containing `.localized` (0 bytes) hit `files[2].size must be > 0`, failing the entire 7-file batch

## Why this is safe
There's no downstream constraint that requires size > 0:
- HEAD verification (right below the validation) already enforces agent-reported size matches what S3 stored
- Postgres storage rollups (`IncrementPackageStorage`, `IncrementDatasetStorage`, etc.) treat 0 as a no-op
- DynamoDB writes carry size as a value with no constraint
- Synthesized S3 events propagate the size; real S3 events absolutely can carry `Size: 0`, so the upload-lambda already handles them
- SHA256 for empty input has a canonical, well-defined value (`47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=`) — the SDK computes it correctly via single-part PutObject

## Why 0-byte files matter
Empty files are legitimate content that scientific datasets contain organically:
- `.gitkeep` / `.keep` placeholders preserving directory structure
- Empty `__init__.py` in Python packages
- BIDS dataset spec placeholders
- Sentinel/lock files
- "Experiment attempted, produced no data" stubs that *are* the metadata

S3 supports 0-byte objects natively. A platform that drops them corrupts the user's hierarchy.

## Test plan
- [ ] `go build ./...` — clean
- [ ] Existing `manifest_test.go` still passes locally with docker-compose test infra
- [ ] After deploy: re-finalize a manifest containing a 0-byte file (e.g. via `pennsieve upload manifest`) and verify it lands at `Finalized` server-side rather than 400-ing the batch
- [ ] Verify negative-size payload still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)