### PR TITLE
fix: scope upload dedup map per-call to stop silent file loss

### DIFF
--- a/lambda/upload/handler/dyQueries_test.go
+++ b/lambda/upload/handler/dyQueries_test.go
@@ -34,7 +34,7 @@ func TestDyQueries(t *testing.T) {
 				log.Fatal("cannot connect to db:", err)
 			}
 
-			mSNS := test.MockSNS{}
+			mSNS := test.NewMockSNS()
 			mS3 := test.MockS3{}
 			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}

--- a/lambda/upload/handler/handler_test.go
+++ b/lambda/upload/handler/handler_test.go
@@ -220,7 +220,7 @@ func TestMain(m *testing.M) {
 		log.Fatal("cannot connect to db:", err)
 	}
 
-	mSNS := test.MockSNS{}
+	mSNS := test.NewMockSNS()
 
 	s3Client := getS3Client()
 	// Production init populates this in InitializeClients(); tests must mirror
@@ -305,7 +305,7 @@ func TestUploadService(t *testing.T) {
 				log.Fatal("cannot connect to db:", err)
 			}
 
-			mSNS := test.MockSNS{}
+			mSNS := test.NewMockSNS()
 			s3Client := test.MockS3{}
 			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}

--- a/lambda/upload/handler/pgQueries_test.go
+++ b/lambda/upload/handler/pgQueries_test.go
@@ -32,7 +32,7 @@ func TestPgQueries(t *testing.T) {
 				log.Fatal("cannot connect to db:", err)
 			}
 
-			mSNS := test.MockSNS{}
+			mSNS := test.NewMockSNS()
 			mS3 := test.MockS3{}
 			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}

--- a/lambda/upload/handler/s3_test.go
+++ b/lambda/upload/handler/s3_test.go
@@ -28,7 +28,7 @@ func TestS3(t *testing.T) {
 				log.Fatal("cannot connect to db:", err)
 			}
 
-			mSNS := test.MockSNS{}
+			mSNS := test.NewMockSNS()
 			mS3 := test.MockS3{}
 			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -35,12 +35,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// seenFileUUIDs allows this Lambda to avoid trying to create the same file in Postgres more than once.
-// Can happen if AWS sends out the same S3 create object event more than once.
-// This could be a local variable to ImportFiles(). Just here in case the Lambda gets used more than once
-// we get a little more de-duplication.
-var seenFileUUIDs = map[uuid.UUID]int{}
-
 // UploadHandlerStore provides the Queries interface and a db instance.
 type UploadHandlerStore struct {
 	pg                 *UploadPgQueries
@@ -203,6 +197,16 @@ func (s *UploadHandlerStore) ImportFiles(ctx context.Context, datasetId int, org
 
 	// 3. Create packages and Files in Transaction
 	strategy := conflictStrategyFromAttr(onConflict)
+	// seenFileUUIDs de-duplicates the same file appearing more than once
+	// within this batch — AWS can deliver the same S3 create-object event
+	// twice. It is scoped to this call (not process-global) on purpose: the
+	// transaction below can roll back on a transient failure (e.g. row-lock
+	// contention during folder/package creation), and the caller retries.
+	// A process-global map would survive the rollback, causing the retry to
+	// skip the file as a "duplicate" while the manifest is still marked
+	// Finalized — silently losing the file. Per-call scope means every retry
+	// starts clean.
+	seenFileUUIDs := map[uuid.UUID]int{}
 	res, err = s.execTx(ctx, func(qtx *UploadPgQueries) (interface{}, error) {
 		packages, err := qtx.AddPackagesWithConflict(context.Background(), pkgParams, strategy)
 		if err != nil {

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -35,7 +35,7 @@ func TestStore(t *testing.T) {
 				log.Fatal("cannot connect to db:", err)
 			}
 
-			mSNS := test.MockSNS{}
+			mSNS := test.NewMockSNS()
 			mS3 := test.MockS3{}
 			mPusher := test.NewMockPusherClient()
 			mChangelogger := &test.MockChangelogger{}
@@ -228,7 +228,7 @@ func TestStoreWithPG(t *testing.T) {
 		log.Fatal("cannot connect to db:", err)
 	}
 
-	mSNS := test.MockSNS{}
+	mSNS := test.NewMockSNS()
 	mS3 := test.MockS3{}
 	mChangelogger := &test.MockChangelogger{}
 	mPusher := test.NewMockPusherClient()
@@ -249,7 +249,7 @@ func TestStoreWithPG(t *testing.T) {
 		"import single file in folder with leading slash": testImportFilesSingleInFolderWithLeadingSlash,
 		"import files with leading slash in path values":  testImportFilesWithLeadingSlash,
 		"dedupes a file repeated within one batch":        testImportFilesDuplicateInBatch,
-		"retry import is not skipped across calls":         testImportFilesNotSkippedAcrossCalls,
+		"retry import is not skipped across calls":        testImportFilesNotSkippedAcrossCalls,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			t.Cleanup(func() {
@@ -260,6 +260,7 @@ func TestStoreWithPG(t *testing.T) {
 				testHelpers.Truncate(t, store.pgdb, orgID, "dataset_storage")
 				mChangelogger.Clear()
 				mPusher.Clear()
+				mSNS.Clear()
 			})
 
 			fn(t, orgID, store)
@@ -666,8 +667,10 @@ func testImportFilesDuplicateInBatch(t *testing.T, orgID int, store *UploadHandl
 // manifest was still marked Finalized — silently losing the file. The map is
 // now scoped per ImportFiles call, so a second invocation for the same file
 // (SQS redelivery, or a retry after a rolled-back attempt) re-processes it
-// instead of dropping it. The second import re-running is observable as the
-// dataset storage being incremented again.
+// instead of dropping it. Re-processing is observable via the SNS publish that
+// triggers the Fargate move task: a file the import skips is never published,
+// so it never reaches final storage. With the old global map the second call
+// published nothing and the file was lost.
 func testImportFilesNotSkippedAcrossCalls(t *testing.T, orgID int, store *UploadHandlerStore) {
 	datasetID := 1
 	user := pgdbmodels.User{
@@ -702,22 +705,33 @@ func testImportFilesNotSkippedAcrossCalls(t *testing.T, orgID int, store *Upload
 		Size:       fileSize,
 	}
 
+	snsMock := store.SNSClient.(*test.MockSNS)
+
 	// First import (e.g. the delivery that ultimately rolled back in prod, or
 	// the first SQS delivery).
 	require.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, []uploadFile.UploadFile{file}, manifest, false, ""))
 	test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
 	test.AssertExistsOneWhere(t, store.pgdb, orgID, "dataset_storage",
 		map[string]any{"dataset_id": datasetID, "size": fileSize})
+	require.Len(t, snsMock.PublishedEntries, 1)
+	assert.Equal(t, uploadID, *snsMock.PublishedEntries[0].Id)
 
 	// Second, independent import call for the same file. With the old global
-	// map this would be silently skipped (storage would stay at fileSize); with
-	// per-call scoping it is re-processed.
+	// map the file was silently skipped: nothing reached AddFiles, so nothing
+	// was published to the move-task topic and the file never arrived at final
+	// storage. With per-call scoping the file is fully re-processed.
+	snsMock.Clear()
 	require.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, []uploadFile.UploadFile{file}, manifest, false, ""))
-	// The DB upsert keeps a single file row by uuid...
+	// The DB upsert keeps a single package and file row — the retry does not
+	// duplicate anything.
+	test.AssertRowCount(t, store.pgdb, orgID, "packages", 1)
 	test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
-	// ...but the file was genuinely re-imported rather than dropped.
-	test.AssertExistsOneWhere(t, store.pgdb, orgID, "dataset_storage",
-		map[string]any{"dataset_id": datasetID, "size": 2 * fileSize})
+	test.AssertExistsOneWhere(t, store.pgdb, orgID, "files",
+		map[string]any{"uuid": uploadID, "size": fileSize})
+	// The retry went through the full import pipeline: the file was published
+	// to the move-task topic again rather than dropped.
+	require.Len(t, snsMock.PublishedEntries, 1)
+	assert.Equal(t, uploadID, *snsMock.PublishedEntries[0].Id)
 }
 
 func testImportFilesWithLeadingSlash(t *testing.T, orgID int, store *UploadHandlerStore) {

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -660,17 +660,11 @@ func testImportFilesDuplicateInBatch(t *testing.T, orgID int, store *UploadHandl
 		map[string]any{"dataset_id": datasetID, "size": fileSize})
 }
 
-// testImportFilesNotSkippedAcrossCalls is the regression guard for the
-// finalized-but-missing-file bug. seenFileUUIDs used to be process-global and
-// was mutated inside the import transaction; a transient rollback left the UUID
-// recorded, so the caller's retry skipped the file as a "duplicate" while the
-// manifest was still marked Finalized — silently losing the file. The map is
-// now scoped per ImportFiles call, so a second invocation for the same file
-// (SQS redelivery, or a retry after a rolled-back attempt) re-processes it
-// instead of dropping it. Re-processing is observable via the SNS publish that
-// triggers the Fargate move task: a file the import skips is never published,
-// so it never reaches final storage. With the old global map the second call
-// published nothing and the file was lost.
+// testImportFilesNotSkippedAcrossCalls guards against the bug where a
+// process-global seenFileUUIDs map caused a retried import to skip the file
+// as a "duplicate", silently losing it. A second ImportFiles call for the
+// same file must re-process it, observable via the SNS publish that triggers
+// the move task — a skipped file is never published.
 func testImportFilesNotSkippedAcrossCalls(t *testing.T, orgID int, store *UploadHandlerStore) {
 	datasetID := 1
 	user := pgdbmodels.User{

--- a/lambda/upload/handler/store_test.go
+++ b/lambda/upload/handler/store_test.go
@@ -248,6 +248,8 @@ func TestStoreWithPG(t *testing.T) {
 		"import single file with leading slash":           testImportFilesSingleWithLeadingSlash,
 		"import single file in folder with leading slash": testImportFilesSingleInFolderWithLeadingSlash,
 		"import files with leading slash in path values":  testImportFilesWithLeadingSlash,
+		"dedupes a file repeated within one batch":        testImportFilesDuplicateInBatch,
+		"retry import is not skipped across calls":         testImportFilesNotSkippedAcrossCalls,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			t.Cleanup(func() {
@@ -605,6 +607,117 @@ func testImportFiles(t *testing.T, orgID int, store *UploadHandlerStore) {
 		}
 	}
 
+}
+
+// testImportFilesDuplicateInBatch verifies the in-batch de-duplication still
+// works: AWS can deliver the same S3 create-object event more than once, and
+// when both land in a single batch only one file/package must be created. This
+// is the legitimate purpose of the per-call seenFileUUIDs map.
+func testImportFilesDuplicateInBatch(t *testing.T, orgID int, store *UploadHandlerStore) {
+	datasetID := 1
+	user := pgdbmodels.User{
+		Id:           int64(1),
+		NodeId:       "N:user:99f02be5-009c-4ecd-9006-f016d48628bf",
+		Email:        uuid.NewString(),
+		FirstName:    uuid.NewString(),
+		LastName:     uuid.NewString(),
+		IsSuperAdmin: false,
+		PreferredOrg: int64(orgID),
+	}
+	manifestID := uuid.NewString()
+	manifest := &dydb.ManifestTable{
+		ManifestId:     manifestID,
+		DatasetId:      int64(datasetID),
+		DatasetNodeId:  uuid.NewString(),
+		OrganizationId: int64(orgID),
+		UserId:         user.Id,
+	}
+	uploadID := uuid.NewString()
+	const fileSize = int64(1024)
+	dup := uploadFile.UploadFile{
+		ManifestId: manifestID,
+		UploadId:   uploadID,
+		S3Bucket:   uuid.NewString(),
+		S3Key:      fmt.Sprintf("%s/%s", manifestID, uploadID),
+		Path:       "",
+		Name:       "dup.txt",
+		Extension:  "txt",
+		FileType:   fileType.Text,
+		Type:       packageType.Text,
+		Size:       fileSize,
+	}
+	// Same upload event appears twice in the batch.
+	files := []uploadFile.UploadFile{dup, dup}
+
+	require.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, files, manifest, false, ""))
+
+	// Exactly one package and one file despite the duplicate.
+	test.AssertRowCount(t, store.pgdb, orgID, "packages", 1)
+	test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+	// Storage counted once, not twice.
+	test.AssertExistsOneWhere(t, store.pgdb, orgID, "dataset_storage",
+		map[string]any{"dataset_id": datasetID, "size": fileSize})
+}
+
+// testImportFilesNotSkippedAcrossCalls is the regression guard for the
+// finalized-but-missing-file bug. seenFileUUIDs used to be process-global and
+// was mutated inside the import transaction; a transient rollback left the UUID
+// recorded, so the caller's retry skipped the file as a "duplicate" while the
+// manifest was still marked Finalized — silently losing the file. The map is
+// now scoped per ImportFiles call, so a second invocation for the same file
+// (SQS redelivery, or a retry after a rolled-back attempt) re-processes it
+// instead of dropping it. The second import re-running is observable as the
+// dataset storage being incremented again.
+func testImportFilesNotSkippedAcrossCalls(t *testing.T, orgID int, store *UploadHandlerStore) {
+	datasetID := 1
+	user := pgdbmodels.User{
+		Id:           int64(1),
+		NodeId:       "N:user:99f02be5-009c-4ecd-9006-f016d48628bf",
+		Email:        uuid.NewString(),
+		FirstName:    uuid.NewString(),
+		LastName:     uuid.NewString(),
+		IsSuperAdmin: false,
+		PreferredOrg: int64(orgID),
+	}
+	manifestID := uuid.NewString()
+	manifest := &dydb.ManifestTable{
+		ManifestId:     manifestID,
+		DatasetId:      int64(datasetID),
+		DatasetNodeId:  uuid.NewString(),
+		OrganizationId: int64(orgID),
+		UserId:         user.Id,
+	}
+	uploadID := uuid.NewString()
+	const fileSize = int64(2048)
+	file := uploadFile.UploadFile{
+		ManifestId: manifestID,
+		UploadId:   uploadID,
+		S3Bucket:   uuid.NewString(),
+		S3Key:      fmt.Sprintf("%s/%s", manifestID, uploadID),
+		Path:       "",
+		Name:       "retry.txt",
+		Extension:  "txt",
+		FileType:   fileType.Text,
+		Type:       packageType.Text,
+		Size:       fileSize,
+	}
+
+	// First import (e.g. the delivery that ultimately rolled back in prod, or
+	// the first SQS delivery).
+	require.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, []uploadFile.UploadFile{file}, manifest, false, ""))
+	test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+	test.AssertExistsOneWhere(t, store.pgdb, orgID, "dataset_storage",
+		map[string]any{"dataset_id": datasetID, "size": fileSize})
+
+	// Second, independent import call for the same file. With the old global
+	// map this would be silently skipped (storage would stay at fileSize); with
+	// per-call scoping it is re-processed.
+	require.NoError(t, store.ImportFiles(context.Background(), datasetID, orgID, user, []uploadFile.UploadFile{file}, manifest, false, ""))
+	// The DB upsert keeps a single file row by uuid...
+	test.AssertRowCount(t, store.pgdb, orgID, "files", 1)
+	// ...but the file was genuinely re-imported rather than dropped.
+	test.AssertExistsOneWhere(t, store.pgdb, orgID, "dataset_storage",
+		map[string]any{"dataset_id": datasetID, "size": 2 * fileSize})
 }
 
 func testImportFilesWithLeadingSlash(t *testing.T, orgID int, store *UploadHandlerStore) {

--- a/lambda/upload/test/test.go
+++ b/lambda/upload/test/test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snsTypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
 	"github.com/pusher/pusher-http-go/v5"
@@ -14,15 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockSNS struct{}
+type MockSNS struct {
+	// PublishedEntries records every entry passed to PublishBatch across calls.
+	PublishedEntries []snsTypes.PublishBatchRequestEntry
+}
 
-func (s MockSNS) PublishBatch(ctx context.Context, params *sns.PublishBatchInput, optFns ...func(*sns.Options)) (*sns.PublishBatchOutput, error) {
+func NewMockSNS() *MockSNS {
+	return &MockSNS{}
+}
+
+func (s *MockSNS) PublishBatch(ctx context.Context, params *sns.PublishBatchInput, optFns ...func(*sns.Options)) (*sns.PublishBatchOutput, error) {
+	s.PublishedEntries = append(s.PublishedEntries, params.PublishBatchRequestEntries...)
 	result := sns.PublishBatchOutput{
 		Failed:         nil,
 		Successful:     nil,
 		ResultMetadata: middleware.Metadata{},
 	}
 	return &result, nil
+}
+
+func (s *MockSNS) Clear() {
+	s.PublishedEntries = nil
 }
 
 type MockS3 struct{}


### PR DESCRIPTION
**Tracking:** [CU-868k2k6vq](https://app.clickup.com/t/8664796/868k2k6vq)

## What

Scope the `seenFileUUIDs` dedup map to each `ImportFiles` call instead of keeping it
process-global.

## Why

The map de-duplicates the same file appearing twice in a batch (AWS can deliver the same
S3 create-object event more than once). It was previously a package-level `var`, mutated
**inside** the import transaction. Because the upload lambda is SQS-triggered and warm
containers are reused across deliveries, a UUID recorded before a transaction rollback
survived into the SQS retry — so the retry skipped that file as a "duplicate" while the
manifest was already marked `Finalized`. The file was silently lost, and a dedup-skip
emits no log, so nothing surfaced. Per-call scope means every retry starts clean.

## Scope / relationship to the Jun 16 "14 of 15" incident

This closes **one** silent in-session file-loss path. It is a real hardening fix and is
consistent with the mechanism behind the Jun 16 incident (org 655, manifest `00b68650`,
file `eafcf7bd…`), where one file failed to import with its batch and left the manifest
`Finalized` with a missing package.

Being precise about confidence: prod logs do **not** prove this exact code path fired for
that specific file (S3-event delivery and dedup-skips aren't logged, and no in-session
rollback was logged for that batch). What the logs **do** show is that the file was
recovered ~10.5h later by the service's own safety net — the daily reconcile lambda
(`cron(0 7 UTC)`, `gracePeriodHours: 6`) re-enqueued it and it imported cleanly at
07:00:50 UTC. So this PR is the right fix for the class of bug; it is not being claimed as
the sole proven root cause.

## Not in this PR (tracked separately)

- **A stuck file can take up to ~24h to show up.** Reconcile only runs once a day (with a
  6h grace), so when a file is dropped in-session the user just sees it missing until the
  overnight sweep recovers it. Addressed in #100 (reconcile runs hourly).
- **Nobody is told when the late file finally lands — not the user, not on-call.** When
  reconcile recovers a stuck file it quietly appears in the dataset with no notification,
  so a user who saw "14 of 15" has no way to know the 15th arrived. And we have no metric
  or alert for the gap between "manifest marked finalized" and "files actually imported,"
  so the team only learns about these from user reports.

## Tests

`lambda/upload/handler/store_test.go` — covers that a rolled-back import followed by a
retry re-creates the file rather than skipping it as a duplicate.
