### PR TITLE
chore: run reconcile hourly to cut stuck-file recovery latency

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -127,15 +127,16 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_archive_sweeper_gr
 # RECONCILE SCHEDULE + ALARMS        #
 ######################################
 #
-# Fires the reconcile-orphans lambda daily with a 6-hour grace period. The
+# Fires the reconcile-orphans lambda hourly with a 6-hour grace period. The
 # interleaved sync+upload in the agent keeps files in Registered for seconds
 # to minutes per file even on large manifests, so 6 hours is a safe buffer
-# for single-day legitimate uploads.
+# for single-day legitimate uploads. Hourly (vs. the previous daily) cadence
+# caps worst-case recovery of a stuck-Registered file at ~7h instead of ~24h.
 
 resource "aws_cloudwatch_event_rule" "reconcile_schedule" {
-  name                = "${var.environment_name}-${var.service_name}-reconcile-daily-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  description         = "Daily sweep for stuck-Registered manifest files past the 6h grace period."
-  schedule_expression = "cron(0 7 * * ? *)" # 07:00 UTC = 02:00 US/Central = 03:00 US/Eastern
+  name                = "${var.environment_name}-${var.service_name}-reconcile-hourly-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  description         = "Hourly sweep for stuck-Registered manifest files past the 6h grace period."
+  schedule_expression = "cron(0 * * * ? *)" # top of every hour, UTC
 }
 
 resource "aws_cloudwatch_event_target" "reconcile_schedule_target" {
@@ -156,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "orphans_missing" {
   evaluation_periods  = 1
   metric_name         = "OrphansMissing"
   namespace           = "UploadService/Reconcile"
-  period              = 86400
+  period              = 3600
   statistic           = "Sum"
   threshold           = 10
   treat_missing_data  = "notBreaching"
@@ -171,7 +172,7 @@ resource "aws_cloudwatch_metric_alarm" "reconciliation_errors" {
   evaluation_periods  = 1
   metric_name         = "ReconciliationErrors"
   namespace           = "UploadService/Reconcile"
-  period              = 86400
+  period              = 3600
   statistic           = "Sum"
   threshold           = 0
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
**Tracking:** [CU-868k2k6vq](https://app.clickup.com/t/8664796/868k2k6vq)
**Related:** #99 (the in-session dedup fix — this PR is the recovery-latency half)

## What

Run the reconcile-orphans sweep **hourly** instead of daily. Grace period unchanged (6h).

- `reconcile_schedule`: `cron(0 7 * * ? *)` → `cron(0 * * * ? *)` (top of every hour, UTC).
- Rule renamed `…-reconcile-daily-…` → `…-reconcile-hourly-…` for accuracy (Terraform
  replaces the rule; the target and lambda invoke permission reference it by resource
  attribute, so they cascade with no manual step).
- Both reconcile alarms (`orphans_missing`, `reconciliation_errors`): `period` 86400 → 3600.

## Why

Reconcile is the safety net that re-enqueues a file whose in-session import was dropped
but whose bytes are in S3. It ran only once a day with a 6h grace, so a dropped file could
stay missing for up to ~24h. In the Jun 16 "14 of 15" incident the recovered file waited
~10.5h. Hourly cadence caps worst-case recovery at ~7h (still bounded below by the 6h
grace), with no change to the safety guarantees.

### Why the alarm periods change too

Both alarms `Sum` a per-run count over their `period`. At daily cadence, `period = 86400`
meant "one run's worth." At hourly cadence that window now spans ~24 runs, so:

- `orphans_missing` (threshold 10): a single genuinely-missing file (a real client-side
  upload failure) would be recounted every hour → ~24/day → false alarm. `period = 3600`
  restores the intended "N missing in a single run" semantics.
- `reconciliation_errors` (threshold 0): keeps the alarm reflecting "a run just failed"
  and re-evaluating hourly, instead of staying in ALARM for 24h after one transient error.

## Not in this PR

- The in-session dedup fix that reduces how often files get dropped in the first place: #99.
- User-facing completion signal + finalized-vs-imported divergence metric: CU-868k2k6vq.

## Deploy note

Applying replaces the EventBridge rule (rename) and updates the two alarm periods. No data
touched; reconcile itself never deletes anything.
