### PR TITLE
reconcile: stop re-enqueueing files for deleted datasets; run hourly

### DIFF
--- a/lambda/reconcile/handler/handler.go
+++ b/lambda/reconcile/handler/handler.go
@@ -1,23 +1,36 @@
 // Package handler implements the reconcile-orphans lambda.
 //
-// Two invocation modes share the same code path:
+// Three invocation modes share the same code path:
 //
 //  1. One-shot manifest recovery (operator-triggered).
 //     Payload: {"manifestNodeId": "<uuid>"}.
 //     Scans manifest_files for that manifest, HEADs each expected storage
 //     key, enqueues recoverable files to upload_trigger_queue.
 //
-//  2. Scheduled sweep (EventBridge, daily).
+//  2. Scheduled sweep (EventBridge, hourly).
 //     Payload: {"gracePeriodHours": 6}.
 //     Scans the StatusIndex GSI for every manifest_files row in "Registered"
 //     status whose manifest's DateCreated is older than gracePeriodHours,
 //     applies the same HEAD-then-enqueue recovery.
 //
-// Never deletes anything. Recovery means "HEAD succeeded, synthesized S3
-// event sent to upload_trigger_queue"; from that point the existing upload
-// lambda consumer imports the file and transitions the DynamoDB row to
-// Finalized. Files whose S3 object is absent (case B in the orphan taxonomy)
-// are counted as "missing" and logged for operator follow-up.
+//  3. Failed-orphan audit (operator-triggered, read-only).
+//     Payload: {"reportOnly": true}.
+//     Scans the StatusIndex GSI for "FailedOrphan" rows and reports how many
+//     still have an object in the storage bucket, and how many bytes those
+//     hold. Writes nothing at all — not even a status flip. Exists so the
+//     question "is there anything worth cleaning up?" can be answered with a
+//     number before anyone builds a deletion path.
+//
+// Never deletes anything, in any mode. Recovery means "HEAD succeeded,
+// synthesized S3 event sent to upload_trigger_queue"; from that point the
+// existing upload lambda consumer imports the file and transitions the DynamoDB
+// row to Finalized. Files whose S3 object is absent (case B in the orphan
+// taxonomy) are counted as "missing" and logged for operator follow-up.
+//
+// Note that FailedOrphan is not a tombstone: the service lambda's
+// resetFailedOrphans flips those rows back to Registered when a user re-syncs a
+// manifest containing them, so anything acting on this report has to assume the
+// set can shrink underneath it.
 package handler
 
 import (
@@ -75,20 +88,53 @@ func InitializeClients() {
 }
 
 // Payload is the JSON body that invokes the lambda. Exactly one of
-// ManifestNodeID or GracePeriodHours should be set. Concurrency caps the
-// number of in-flight HEAD requests; default is 16, which suits a 512 MB
-// Lambda (HEAD is network-bound, not CPU-bound).
+// ManifestNodeID, GracePeriodHours or ReportOnly should be set. Concurrency
+// caps the number of in-flight HEAD requests; default is 16, which suits a
+// 512 MB Lambda (HEAD is network-bound, not CPU-bound).
 type Payload struct {
 	ManifestNodeID   string `json:"manifestNodeId,omitempty"`
 	GracePeriodHours int    `json:"gracePeriodHours,omitempty"`
 	DryRun           bool   `json:"dryRun,omitempty"`
 	Concurrency      int    `json:"concurrency,omitempty"`
+
+	// ReportOnly runs a third, strictly read-only mode: audit every
+	// FailedOrphan row and report which ones still have bytes sitting in the
+	// storage bucket. Writes nothing, enqueues nothing, deletes nothing.
+	//
+	// This exists to size the population a future cleanup tool would target,
+	// before anyone builds one. As of 2026-07-29 a sample of the top 30
+	// manifests in prod (13,890 of 20,640 rows) found zero surviving objects —
+	// FailedOrphan is currently reached almost entirely via the HEAD-404 path,
+	// where the client never finished its PUT, so there were never any bytes.
+	// Deleted-dataset orphans are the first case that can leave real bytes
+	// behind, so watch this number after that change ships.
+	ReportOnly bool `json:"reportOnly,omitempty"`
 }
 
 const (
 	defaultConcurrency = 16
 	maxConcurrency     = 64
 )
+
+// validatePayload enforces exactly one mode. Kept separate from Handle so it is
+// testable without AWS clients or a Postgres connection — Handle's first real
+// action is ConnectRDS, so an invalid payload must be rejected before that.
+func validatePayload(p Payload) error {
+	modes := 0
+	if p.ManifestNodeID != "" {
+		modes++
+	}
+	if p.GracePeriodHours != 0 {
+		modes++
+	}
+	if p.ReportOnly {
+		modes++
+	}
+	if modes != 1 {
+		return errors.New("exactly one of manifestNodeId, gracePeriodHours or reportOnly must be set")
+	}
+	return nil
+}
 
 // Result is the aggregate outcome of a reconciliation run.
 type Result struct {
@@ -100,6 +146,9 @@ type Result struct {
 	Errors           []string                 `json:"errors,omitempty"`
 	PerManifest      map[string]ManifestStats `json:"perManifest,omitempty"`
 	DryRun           bool                     `json:"dryRun"`
+
+	// Report is populated only by reportOnly runs.
+	Report *OrphanReport `json:"report,omitempty"`
 }
 
 type ManifestStats struct {
@@ -108,12 +157,42 @@ type ManifestStats struct {
 	Missing      int `json:"missing"`
 }
 
+// OrphanReport is the outcome of a reportOnly run: how many FailedOrphan rows
+// still have a corresponding object in the storage bucket, and how many bytes
+// those objects hold.
+//
+// ObjectsPresent is the number that a cleanup tool could actually reclaim.
+// ObjectsAbsent is the expected common case — the row is a tombstone for an
+// upload whose bytes never landed, so there is nothing to reclaim and nothing
+// to delete.
+type OrphanReport struct {
+	FilesScanned   int   `json:"filesScanned"`
+	ObjectsPresent int   `json:"objectsPresent"`
+	ObjectsAbsent  int   `json:"objectsAbsent"`
+	BytesPresent   int64 `json:"bytesPresent"`
+	// HeadErrors counts rows we could not classify (5xx, permission, region
+	// lookup). They are neither present nor absent — a nonzero value means the
+	// report undercounts and should be re-run before acting on it.
+	HeadErrors  int                            `json:"headErrors"`
+	PerManifest map[string]OrphanManifestStats `json:"perManifest,omitempty"`
+}
+
+type OrphanManifestStats struct {
+	FilesScanned   int   `json:"filesScanned"`
+	ObjectsPresent int   `json:"objectsPresent"`
+	BytesPresent   int64 `json:"bytesPresent"`
+	// Set when the manifest's dataset row is gone. These are the orphans most
+	// likely to hold real bytes, since the upload succeeded and only the import
+	// was impossible.
+	DatasetGone bool `json:"datasetGone,omitempty"`
+}
+
 // Handle is the Lambda entrypoint. Loads a short-lived Postgres connection
 // via RDS Proxy (required for storage-bucket resolution), dispatches on
 // payload shape, and emits a summary record the scheduled alarm watches.
 func Handle(ctx context.Context, p Payload) (Result, error) {
-	if (p.ManifestNodeID == "") == (p.GracePeriodHours == 0) {
-		return Result{}, errors.New("exactly one of manifestNodeId or gracePeriodHours must be set")
+	if err := validatePayload(p); err != nil {
+		return Result{}, err
 	}
 
 	pgdb, err := pgQueries.ConnectRDS()
@@ -177,11 +256,16 @@ func Handle(ctx context.Context, p Payload) (Result, error) {
 	}()
 	defer close(progressDone)
 
-	if p.ManifestNodeID != "" {
+	switch {
+	case p.ReportOnly:
+		if err := store.reportFailedOrphans(ctx, concurrency, &result); err != nil {
+			result.Errors = append(result.Errors, err.Error())
+		}
+	case p.ManifestNodeID != "":
 		if err := store.reconcileManifest(ctx, p.ManifestNodeID, p.DryRun, concurrency, &result); err != nil {
 			result.Errors = append(result.Errors, err.Error())
 		}
-	} else {
+	default:
 		if err := store.reconcileByGracePeriod(ctx, p.GracePeriodHours, p.DryRun, concurrency, &result); err != nil {
 			result.Errors = append(result.Errors, err.Error())
 		}
@@ -197,27 +281,53 @@ func Handle(ctx context.Context, p Payload) (Result, error) {
 // emitMetrics writes a CloudWatch EMF record so `OrphansRecovered`,
 // `OrphansMissing`, and `ReconciliationErrors` show up as metrics without a
 // separate PutMetricData call. Alarms/dashboards consume these directly.
+//
+// reportOnly runs additionally emit OrphanedObjectsPresent / OrphanedBytesPresent.
+// Those are deliberately not on a schedule and have no alarm — reportOnly is
+// operator-invoked, so the metrics only appear when someone asks the question.
 func emitMetrics(r Result) {
+	line, _ := json.Marshal(buildEMF(r))
+	// stdout so Lambda picks it up as a log line and parses the EMF block.
+	fmt.Println(string(line))
+}
+
+// buildEMF is split out from emitMetrics purely so tests can assert on which
+// metrics a given Result publishes without capturing stdout.
+func buildEMF(r Result) map[string]any {
+	metrics := []map[string]string{
+		{"Name": "OrphansRecovered", "Unit": "Count"},
+		{"Name": "OrphansMissing", "Unit": "Count"},
+		{"Name": "ReconciliationErrors", "Unit": "Count"},
+		{"Name": "EnqueueFailed", "Unit": "Count"},
+	}
+	values := map[string]any{
+		"OrphansRecovered":     r.Recovered,
+		"OrphansMissing":       r.Missing,
+		"ReconciliationErrors": len(r.Errors),
+		"EnqueueFailed":        r.EnqueueFailed,
+	}
+
+	if r.Report != nil {
+		metrics = append(metrics,
+			map[string]string{"Name": "OrphanedObjectsPresent", "Unit": "Count"},
+			map[string]string{"Name": "OrphanedBytesPresent", "Unit": "Bytes"},
+		)
+		values["OrphanedObjectsPresent"] = r.Report.ObjectsPresent
+		values["OrphanedBytesPresent"] = r.Report.BytesPresent
+	}
+
 	emf := map[string]any{
 		"_aws": map[string]any{
 			"Timestamp": timestampMillis(),
 			"CloudWatchMetrics": []map[string]any{{
 				"Namespace":  "UploadService/Reconcile",
 				"Dimensions": [][]string{{}},
-				"Metrics": []map[string]string{
-					{"Name": "OrphansRecovered", "Unit": "Count"},
-					{"Name": "OrphansMissing", "Unit": "Count"},
-					{"Name": "ReconciliationErrors", "Unit": "Count"},
-					{"Name": "EnqueueFailed", "Unit": "Count"},
-				},
+				"Metrics":    metrics,
 			}},
 		},
-		"OrphansRecovered":     r.Recovered,
-		"OrphansMissing":       r.Missing,
-		"ReconciliationErrors": len(r.Errors),
-		"EnqueueFailed":        r.EnqueueFailed,
 	}
-	line, _ := json.Marshal(emf)
-	// stdout so Lambda picks it up as a log line and parses the EMF block.
-	fmt.Println(string(line))
+	for k, v := range values {
+		emf[k] = v
+	}
+	return emf
 }

--- a/lambda/reconcile/handler/store.go
+++ b/lambda/reconcile/handler/store.go
@@ -63,6 +63,37 @@ func (s *store) resolveManifest(ctx context.Context, manifestID string) (*resolv
 	if err != nil {
 		return nil, fmt.Errorf("get organization %d: %w", m.OrganizationId, err)
 	}
+
+	// Confirm the dataset still exists before treating this manifest as
+	// recoverable. Without this check a manifest whose dataset row has been
+	// deleted looks perfectly healthy here — the DynamoDB manifest row and the
+	// org row both survive dataset deletion — so every run HEADs the objects,
+	// re-enqueues them, and the upload lambda fails each one on
+	// packages_dataset_id_fkey. That loop is what pinned the prod
+	// upload_trigger DLQ at ~1470 messages (210 files/day x 7-day retention)
+	// and fired the DLQ alarm daily.
+	//
+	// datasets lives in the per-org schema and pgdb's getDataset issues an
+	// unqualified `FROM datasets`, so the search_path has to be set first.
+	// Safe here because resolveManifest only runs on reconcileByGracePeriod's
+	// paginator goroutine (results are cached per manifest) — the concurrent
+	// HEAD workers never touch Postgres, so no other goroutine can observe a
+	// half-switched search_path.
+	orgPg, err := s.pg.WithOrg(int(m.OrganizationId))
+	if err != nil {
+		return nil, fmt.Errorf("set search_path for org %d: %w", m.OrganizationId, err)
+	}
+	if _, err := orgPg.GetDatasetById(ctx, m.DatasetId); err != nil {
+		// pgdb's scanDataset converts sql.ErrNoRows into a typed
+		// DatasetNotFoundError, so matching on sql.ErrNoRows here would never
+		// fire. Any other error is treated as possibly-transient below.
+		var notFound pgQueries.DatasetNotFoundError
+		if errors.As(err, &notFound) {
+			return nil, fmt.Errorf("%w: dataset %d (org %d)", errDatasetGone, m.DatasetId, m.OrganizationId)
+		}
+		return nil, fmt.Errorf("get dataset %d: %w", m.DatasetId, err)
+	}
+
 	bucket := s.defaultStorageBucket
 	if org.StorageBucket.Valid {
 		bucket = org.StorageBucket.String
@@ -118,11 +149,12 @@ func (s *store) reconcileManifest(ctx context.Context, manifestID string, dryRun
 func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int, dryRun bool, concurrency int, result *Result) error {
 	cutoff := time.Now().Add(-time.Duration(gracePeriodHours) * time.Hour).Unix()
 	cache := make(map[string]*resolvedManifest)
-	// Tracks manifest IDs whose parent row in manifest_table is confirmed
-	// gone (not a transient error). Files pointing at these manifests have
-	// no recoverable state — flip them to FailedOrphan so they drop out of
-	// the StatusIndex=Registered scan on future runs.
-	missingManifests := make(map[string]bool)
+	// Tracks manifest IDs that can never be imported — either the manifest_table
+	// row or the Postgres dataset row is confirmed gone (not a transient error).
+	// Files pointing at these have no recoverable state, so flip them to
+	// FailedOrphan and they drop out of the StatusIndex=Registered scan on
+	// future runs instead of being re-enqueued forever.
+	unrecoverableManifests := make(map[string]bool)
 
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
@@ -155,21 +187,28 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 			if !ok {
 				r, err := s.resolveManifest(ctx, manifestID)
 				if err != nil {
-					log.WithError(err).WithField("manifest_id", manifestID).Warn("resolve failed, skipping manifest")
-					s.mu.Lock()
-					result.Errors = append(result.Errors, err.Error())
-					s.mu.Unlock()
 					cache[manifestID] = nil
-					// Only treat the specific "manifest not found" case as a
-					// clean orphan. Any other resolve error (Postgres 5xx,
-					// throttling, missing org row, etc.) might be transient,
-					// so we skip-without-flipping and let a future run retry.
-					if isManifestNotFound(err) {
-						missingManifests[manifestID] = true
-					}
-					if !missingManifests[manifestID] {
+					// Only permanent failures (manifest row gone, dataset row
+					// gone) become clean orphans. Any other resolve error
+					// (Postgres 5xx, throttling, missing org row, region
+					// lookup) might be transient, so we skip-without-flipping
+					// and let a future run retry.
+					if !isTerminalResolveError(err) {
+						log.WithError(err).WithField("manifest_id", manifestID).Warn("resolve failed, skipping manifest")
+						s.mu.Lock()
+						result.Errors = append(result.Errors, err.Error())
+						s.mu.Unlock()
 						continue
 					}
+					unrecoverableManifests[manifestID] = true
+					// Deliberately NOT appended to result.Errors. This is an
+					// expected terminal state that we handle by flipping the rows
+					// to FailedOrphan; counting it as a reconciliation error would
+					// fire the errors alarm on every run until the flip lands,
+					// which just trains everyone to ignore that alarm. The rows are
+					// still counted toward Missing.
+					log.WithError(err).WithField("manifest_id", manifestID).
+						Info("manifest unrecoverable, flipping its rows to FailedOrphan")
 					// fall through to orphan-mark branch below
 				} else {
 					// Grace period check at the manifest level: skip if the
@@ -184,11 +223,14 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 			}
 
 			if resolved == nil {
-				if !missingManifests[manifestID] {
+				if !unrecoverableManifests[manifestID] {
 					continue
 				}
-				// Parent manifest row is gone — just flip this row to
-				// FailedOrphan. No HEAD needed (no bucket to check).
+				// Manifest is unrecoverable (its row or its dataset is gone) —
+				// just flip this row to FailedOrphan. No HEAD needed: for a
+				// missing manifest there's no bucket to check, and for a deleted
+				// dataset the object may well still be there but can never be
+				// imported.
 				if dryRun {
 					s.bumpScanned(result, manifestID)
 					s.bumpMissing(result, manifestID)
@@ -217,7 +259,7 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 
 	// Count manifests actually visited: cache entries with resolved != nil,
 	// plus confirmed-missing manifests (whose file rows we cleaned up).
-	scanned := len(missingManifests)
+	scanned := len(unrecoverableManifests)
 	for _, r := range cache {
 		if r != nil {
 			scanned++
@@ -229,17 +271,39 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 	return nil
 }
 
-// isManifestNotFound matches the hardcoded error string from
-// pennsieve-go-core's GetManifestById (no sentinel error or typed error
-// exists in that package). Other resolve errors (Postgres failures,
-// throttles, bad org rows) must not trigger an orphan flip.
-func isManifestNotFound(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "Manifest not found")
+// errDatasetGone marks a resolve failure caused by the manifest's dataset row
+// no longer existing in Postgres. A sentinel rather than a string match because
+// this one we raise ourselves.
+var errDatasetGone = errors.New("dataset no longer exists")
+
+// isTerminalResolveError reports whether a resolveManifest failure is permanent,
+// meaning no future run can succeed and the manifest_files rows should be
+// flipped to FailedOrphan rather than retried forever.
+//
+// Two cases qualify:
+//   - the DynamoDB manifest row is gone
+//   - the Postgres dataset row is gone (packages has an FK to datasets, so the
+//     import can never succeed)
+//
+// Everything else — Postgres 5xx, DynamoDB throttling, a missing org row, an
+// S3 region lookup failure — may be transient and must leave the rows in
+// Registered so a later run can retry.
+func isTerminalResolveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errDatasetGone) {
+		return true
+	}
+	// GetManifestById reports a missing manifest with a bare error string;
+	// pennsieve-go-core exposes no sentinel or typed error to match on.
+	return strings.Contains(err.Error(), "Manifest not found")
 }
 
-// markOrphanedRow flips a single manifest_files row whose parent manifest
-// is known-gone. Separate from reconcileFile because there's no bucket or
-// keyPrefix to resolve — all we have is manifestID + uploadID.
+// markOrphanedRow flips a single manifest_files row whose manifest is
+// unrecoverable — either the manifest row or its dataset is known-gone.
+// Separate from reconcileFile because there's no bucket or keyPrefix to
+// resolve (and nothing to HEAD) — all we have is manifestID + uploadID.
 func (s *store) markOrphanedRow(ctx context.Context, manifestID, uploadID string, result *Result) {
 	s.bumpScanned(result, manifestID)
 	if err := s.markFailedOrphan(ctx, manifestID, uploadID); err != nil {
@@ -247,7 +311,7 @@ func (s *store) markOrphanedRow(ctx context.Context, manifestID, uploadID string
 		log.WithError(err).WithFields(log.Fields{
 			"manifest_id": manifestID,
 			"upload_id":   uploadID,
-		}).Warn("failed to mark orphaned row FailedOrphan (parent manifest missing)")
+		}).Warn("failed to mark orphaned row FailedOrphan (manifest or dataset gone)")
 		return
 	}
 	s.bumpMissing(result, manifestID)

--- a/lambda/reconcile/handler/store.go
+++ b/lambda/reconcile/handler/store.go
@@ -53,7 +53,25 @@ type resolvedManifest struct {
 	storageRegion string
 }
 
+// resolveManifest locates a manifest's objects and confirms the manifest is
+// actually importable. Used by the recovery paths, which must not enqueue work
+// that can never succeed.
 func (s *store) resolveManifest(ctx context.Context, manifestID string) (*resolvedManifest, error) {
+	r, err := s.resolveManifestLocation(ctx, manifestID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.assertDatasetExists(ctx, r.manifest); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// resolveManifestLocation works out which bucket, region and key prefix a
+// manifest's objects live under. Deliberately says nothing about whether the
+// manifest can be imported — reportOnly needs to locate objects belonging to
+// deleted datasets, which are exactly the ones resolveManifest rejects.
+func (s *store) resolveManifestLocation(ctx context.Context, manifestID string) (*resolvedManifest, error) {
 	dy := dyQueries.New(s.dy)
 	m, err := dy.GetManifestById(ctx, s.manifestTable, manifestID)
 	if err != nil {
@@ -63,37 +81,6 @@ func (s *store) resolveManifest(ctx context.Context, manifestID string) (*resolv
 	if err != nil {
 		return nil, fmt.Errorf("get organization %d: %w", m.OrganizationId, err)
 	}
-
-	// Confirm the dataset still exists before treating this manifest as
-	// recoverable. Without this check a manifest whose dataset row has been
-	// deleted looks perfectly healthy here — the DynamoDB manifest row and the
-	// org row both survive dataset deletion — so every run HEADs the objects,
-	// re-enqueues them, and the upload lambda fails each one on
-	// packages_dataset_id_fkey. That loop is what pinned the prod
-	// upload_trigger DLQ at ~1470 messages (210 files/day x 7-day retention)
-	// and fired the DLQ alarm daily.
-	//
-	// datasets lives in the per-org schema and pgdb's getDataset issues an
-	// unqualified `FROM datasets`, so the search_path has to be set first.
-	// Safe here because resolveManifest only runs on reconcileByGracePeriod's
-	// paginator goroutine (results are cached per manifest) — the concurrent
-	// HEAD workers never touch Postgres, so no other goroutine can observe a
-	// half-switched search_path.
-	orgPg, err := s.pg.WithOrg(int(m.OrganizationId))
-	if err != nil {
-		return nil, fmt.Errorf("set search_path for org %d: %w", m.OrganizationId, err)
-	}
-	if _, err := orgPg.GetDatasetById(ctx, m.DatasetId); err != nil {
-		// pgdb's scanDataset converts sql.ErrNoRows into a typed
-		// DatasetNotFoundError, so matching on sql.ErrNoRows here would never
-		// fire. Any other error is treated as possibly-transient below.
-		var notFound pgQueries.DatasetNotFoundError
-		if errors.As(err, &notFound) {
-			return nil, fmt.Errorf("%w: dataset %d (org %d)", errDatasetGone, m.DatasetId, m.OrganizationId)
-		}
-		return nil, fmt.Errorf("get dataset %d: %w", m.DatasetId, err)
-	}
-
 	bucket := s.defaultStorageBucket
 	if org.StorageBucket.Valid {
 		bucket = org.StorageBucket.String
@@ -108,6 +95,39 @@ func (s *store) resolveManifest(ctx context.Context, manifestID string) (*resolv
 		keyPrefix:     fmt.Sprintf("O%d/D%d/%s", m.OrganizationId, m.DatasetId, manifestID),
 		storageRegion: region,
 	}, nil
+}
+
+// assertDatasetExists returns errDatasetGone when the manifest's dataset row is
+// no longer in Postgres.
+//
+// Without this check a manifest whose dataset has been deleted looks perfectly
+// healthy — the DynamoDB manifest row and the org row both survive dataset
+// deletion — so every run HEADs the objects, re-enqueues them, and the upload
+// lambda fails each one on packages_dataset_id_fkey. That loop is what pinned
+// the prod upload_trigger DLQ at ~1470 messages (210 files/day x 7-day
+// retention) and fired the DLQ alarm daily.
+//
+// datasets lives in the per-org schema and pgdb's getDataset issues an
+// unqualified `FROM datasets`, so the search_path has to be set first. Safe
+// here because this only runs on reconcileByGracePeriod's paginator goroutine
+// (results are cached per manifest) — the concurrent HEAD workers never touch
+// Postgres, so no other goroutine can observe a half-switched search_path.
+func (s *store) assertDatasetExists(ctx context.Context, m *dydb.ManifestTable) error {
+	orgPg, err := s.pg.WithOrg(int(m.OrganizationId))
+	if err != nil {
+		return fmt.Errorf("set search_path for org %d: %w", m.OrganizationId, err)
+	}
+	if _, err := orgPg.GetDatasetById(ctx, m.DatasetId); err != nil {
+		// pgdb's scanDataset converts sql.ErrNoRows into a typed
+		// DatasetNotFoundError, so matching on sql.ErrNoRows here would never
+		// fire. Any other error is treated as possibly-transient by the caller.
+		var notFound pgQueries.DatasetNotFoundError
+		if errors.As(err, &notFound) {
+			return fmt.Errorf("%w: dataset %d (org %d)", errDatasetGone, m.DatasetId, m.OrganizationId)
+		}
+		return fmt.Errorf("get dataset %d: %w", m.DatasetId, err)
+	}
+	return nil
 }
 
 // reconcileManifest recovers all stuck-Registered files for a single
@@ -269,6 +289,146 @@ func (s *store) reconcileByGracePeriod(ctx context.Context, gracePeriodHours int
 	result.ManifestsScanned = scanned
 	s.mu.Unlock()
 	return nil
+}
+
+// reportFailedOrphans audits every FailedOrphan row and reports which ones still
+// have bytes in the storage bucket. Strictly read-only: no UpdateItem, no
+// SendMessage, no DeleteObject. Its purpose is to size the population a cleanup
+// tool would target, so that decision can be made against a number rather than
+// an assumption.
+//
+// Most FailedOrphan rows are expected to have no object at all — the status is
+// normally reached via the HEAD-404 path, meaning the client never finished its
+// PUT. Rows whose object *does* survive are the interesting ones, and they are
+// broken out per manifest with a datasetGone flag.
+func (s *store) reportFailedOrphans(ctx context.Context, concurrency int, result *Result) error {
+	report := &OrphanReport{PerManifest: make(map[string]OrphanManifestStats)}
+	result.Report = report
+
+	// Resolution is cached per manifest and, like the recovery path, happens on
+	// this goroutine only — assertDatasetExists mutates the connection's
+	// search_path, so it must not race the HEAD workers.
+	type resolution struct {
+		loc         *resolvedManifest
+		datasetGone bool
+		err         error
+	}
+	cache := make(map[string]*resolution)
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	p := dynamodb.NewQueryPaginator(s.dy, &dynamodb.QueryInput{
+		TableName:              aws.String(s.manifestFileTable),
+		IndexName:              aws.String("StatusIndex"),
+		KeyConditionExpression: aws.String("#status = :hashKey"),
+		ExpressionAttributeValues: map[string]dyTypes.AttributeValue{
+			":hashKey": &dyTypes.AttributeValueMemberS{Value: manifestFile.FailedOrphan.String()},
+		},
+		ExpressionAttributeNames: map[string]string{"#status": "Status"},
+	})
+
+	for p.HasMorePages() {
+		page, err := p.NextPage(ctx)
+		if err != nil {
+			wg.Wait()
+			return fmt.Errorf("scan StatusIndex for FailedOrphan: %w", err)
+		}
+		for _, item := range page.Items {
+			var manifestID, uploadID string
+			_ = attributevalue.Unmarshal(item["ManifestId"], &manifestID)
+			_ = attributevalue.Unmarshal(item["UploadId"], &uploadID)
+			if manifestID == "" || uploadID == "" {
+				continue
+			}
+
+			res, ok := cache[manifestID]
+			if !ok {
+				res = &resolution{}
+				loc, err := s.resolveManifestLocation(ctx, manifestID)
+				if err != nil {
+					// Can't locate the objects (manifest row gone, org gone,
+					// region lookup failed). Nothing to report for these beyond
+					// the row count.
+					res.err = err
+					log.WithError(err).WithField("manifest_id", manifestID).
+						Debug("reportFailedOrphans: cannot locate manifest, skipping")
+				} else {
+					res.loc = loc
+					res.datasetGone = errors.Is(s.assertDatasetExists(ctx, loc.manifest), errDatasetGone)
+				}
+				cache[manifestID] = res
+			}
+
+			s.bumpReportScanned(report, manifestID, res.datasetGone)
+			if res.loc == nil {
+				continue
+			}
+
+			sem <- struct{}{}
+			wg.Add(1)
+			go func(loc *resolvedManifest, mid, uid string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				head, err := s.s3.HeadObject(ctx, &s3.HeadObjectInput{
+					Bucket: aws.String(loc.storageBucket),
+					Key:    aws.String(fmt.Sprintf("%s/%s", loc.keyPrefix, uid)),
+				}, func(o *s3.Options) {
+					// Workspace buckets are not all in us-east-1 (there is an
+					// af-south-1 one), and the default client would 301 on those.
+					o.Region = loc.storageRegion
+				})
+				if err != nil {
+					s.mu.Lock()
+					if isS3NotFound(err) {
+						report.ObjectsAbsent++
+					} else {
+						// Unclassifiable — the report undercounts, so say so
+						// rather than silently treating it as absent.
+						report.HeadErrors++
+					}
+					s.mu.Unlock()
+					return
+				}
+				s.bumpReportPresent(report, mid, aws.ToInt64(head.ContentLength))
+			}(res.loc, manifestID, uploadID)
+		}
+	}
+	wg.Wait()
+
+	log.WithFields(log.Fields{
+		"files_scanned":   report.FilesScanned,
+		"objects_present": report.ObjectsPresent,
+		"objects_absent":  report.ObjectsAbsent,
+		"bytes_present":   report.BytesPresent,
+		"head_errors":     report.HeadErrors,
+		"manifests":       len(report.PerManifest),
+	}).Info("failed-orphan report complete")
+	return nil
+}
+
+func (s *store) bumpReportScanned(r *OrphanReport, manifestID string, datasetGone bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.FilesScanned++
+	st := r.PerManifest[manifestID]
+	st.FilesScanned++
+	if datasetGone {
+		st.DatasetGone = true
+	}
+	r.PerManifest[manifestID] = st
+}
+
+func (s *store) bumpReportPresent(r *OrphanReport, manifestID string, size int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.ObjectsPresent++
+	r.BytesPresent += size
+	st := r.PerManifest[manifestID]
+	st.ObjectsPresent++
+	st.BytesPresent += size
+	r.PerManifest[manifestID] = st
 }
 
 // errDatasetGone marks a resolve failure caused by the manifest's dataset row
@@ -480,7 +640,7 @@ func (s *store) markFailedOrphan(ctx context.Context, manifestID, uploadID strin
 		// Drop from the sparse InProgressIndex GSI since FailedOrphan is
 		// terminal. Setting Status alone isn't enough — InProgressIndex is
 		// queried by CheckUpdateManifestStatus to decide manifest completion.
-		UpdateExpression: aws.String("SET #s = :new REMOVE InProgress"),
+		UpdateExpression:    aws.String("SET #s = :new REMOVE InProgress"),
 		ConditionExpression: aws.String("#s = :reg"),
 		ExpressionAttributeNames: map[string]string{
 			"#s": "Status",

--- a/lambda/reconcile/handler/store_test.go
+++ b/lambda/reconcile/handler/store_test.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	pgQueries "github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
+)
+
+// TestIsTerminalResolveError guards the blast radius in both directions.
+//
+// A false negative means a permanently-broken manifest is retried forever: the
+// reconciler re-enqueues its files every run, the upload lambda fails them, and
+// they pile into the dead-letter queue (210 files/day pinned the prod DLQ at
+// ~1470 for six weeks before anyone traced it).
+//
+// A false positive is worse — it flips recoverable rows to FailedOrphan during a
+// transient Postgres or DynamoDB blip, which takes them out of the
+// StatusIndex=Registered scan permanently. Those files stop being retried and
+// only a manual one-shot reconcile brings them back. Anything not positively
+// known to be terminal must classify as transient.
+func TestIsTerminalResolveError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not terminal",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "dataset gone sentinel",
+			err:  fmt.Errorf("%w: dataset 4191 (org 367)", errDatasetGone),
+			want: true,
+		},
+		{
+			name: "dataset gone survives extra wrapping",
+			err:  fmt.Errorf("resolve manifest abc: %w", fmt.Errorf("%w: dataset 1", errDatasetGone)),
+			want: true,
+		},
+		{
+			name: "missing manifest matched by message",
+			err:  errors.New("get manifest abc: Manifest not found"),
+			want: true,
+		},
+		{
+			name: "postgres failure is transient",
+			err:  errors.New("get organization 367: driver: bad connection"),
+			want: false,
+		},
+		{
+			name: "dynamodb throttle is transient",
+			err:  errors.New("ProvisionedThroughputExceededException: slow down"),
+			want: false,
+		},
+		{
+			name: "region lookup failure is transient",
+			err:  errors.New("resolve region for some-bucket: RequestTimeout"),
+			want: false,
+		},
+		{
+			name: "missing org row is transient, not terminal",
+			err:  errors.New("get organization 999: sql: no rows in result set"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTerminalResolveError(tt.err); got != tt.want {
+				t.Errorf("isTerminalResolveError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDatasetNotFoundErrorIsMatchable pins the assumption resolveManifest depends
+// on: pgdb converts sql.ErrNoRows into a typed DatasetNotFoundError rather than
+// propagating ErrNoRows, and that type is reachable through errors.As after
+// wrapping. If a pennsieve-go-core bump changes either, resolveManifest silently
+// stops recognising deleted datasets and the re-enqueue loop returns — with no
+// other test failing.
+func TestDatasetNotFoundErrorIsMatchable(t *testing.T) {
+	wrapped := fmt.Errorf("get dataset 4191: %w", pgQueries.DatasetNotFoundError{ErrorMessage: "No rows were returned!"})
+
+	var notFound pgQueries.DatasetNotFoundError
+	if !errors.As(wrapped, &notFound) {
+		t.Fatal("errors.As failed to match a wrapped DatasetNotFoundError; resolveManifest's deleted-dataset detection is broken")
+	}
+}

--- a/lambda/reconcile/handler/store_test.go
+++ b/lambda/reconcile/handler/store_test.go
@@ -77,6 +77,73 @@ func TestIsTerminalResolveError(t *testing.T) {
 	}
 }
 
+// TestValidatePayload covers mode selection. Handle's first real action is
+// ConnectRDS, so an invalid payload has to be rejected before that — and a
+// payload that accidentally satisfies two modes must not silently pick one,
+// since "reportOnly plus gracePeriodHours" would otherwise run the mutating
+// sweep when the operator asked for a read-only audit.
+func TestValidatePayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload Payload
+		wantErr bool
+	}{
+		{name: "grace period alone", payload: Payload{GracePeriodHours: 6}},
+		{name: "manifest alone", payload: Payload{ManifestNodeID: "abc"}},
+		{name: "reportOnly alone", payload: Payload{ReportOnly: true}},
+		{name: "reportOnly with dryRun is fine", payload: Payload{ReportOnly: true, DryRun: true}},
+		{name: "nothing set", payload: Payload{}, wantErr: true},
+		{name: "empty except concurrency", payload: Payload{Concurrency: 8}, wantErr: true},
+		{name: "reportOnly plus grace period", payload: Payload{ReportOnly: true, GracePeriodHours: 6}, wantErr: true},
+		{name: "reportOnly plus manifest", payload: Payload{ReportOnly: true, ManifestNodeID: "abc"}, wantErr: true},
+		{name: "manifest plus grace period", payload: Payload{ManifestNodeID: "abc", GracePeriodHours: 6}, wantErr: true},
+		{name: "all three", payload: Payload{ReportOnly: true, ManifestNodeID: "abc", GracePeriodHours: 6}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePayload(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePayload(%+v) error = %v, wantErr %v", tt.payload, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestEmitMetricsReportFields checks that reportOnly runs publish the orphan-byte
+// metrics and ordinary runs do not — an always-present zero would make
+// "nobody has measured this" indistinguishable from "measured, and it is zero".
+func TestEmitMetricsReportFields(t *testing.T) {
+	withReport := Result{Report: &OrphanReport{ObjectsPresent: 3, BytesPresent: 4096}}
+	if got := metricNames(withReport); !contains(got, "OrphanedBytesPresent") || !contains(got, "OrphanedObjectsPresent") {
+		t.Errorf("reportOnly run should publish orphan metrics, got %v", got)
+	}
+	if got := metricNames(Result{Recovered: 5}); contains(got, "OrphanedBytesPresent") {
+		t.Errorf("non-report run should not publish orphan metrics, got %v", got)
+	}
+}
+
+// metricNames pulls the published metric names out of the EMF payload.
+func metricNames(r Result) []string {
+	emf := buildEMF(r)
+	aws := emf["_aws"].(map[string]any)
+	defs := aws["CloudWatchMetrics"].([]map[string]any)
+	var out []string
+	for _, m := range defs[0]["Metrics"].([]map[string]string) {
+		out = append(out, m["Name"])
+	}
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // TestDatasetNotFoundErrorIsMatchable pins the assumption resolveManifest depends
 // on: pgdb converts sql.ErrNoRows into a typed DatasetNotFoundError rather than
 // propagating ErrNoRows, and that type is reachable through errors.As after

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -132,6 +132,12 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_archive_sweeper_gr
 # to minutes per file even on large manifests, so 6 hours is a safe buffer
 # for single-day legitimate uploads. Hourly (vs. the previous daily) cadence
 # caps worst-case recovery of a stuck-Registered file at ~7h instead of ~24h.
+#
+# Cutting the grace period below 6h needs a per-file freshness check first.
+# The grace check is evaluated against the *manifest's* DateCreated, which can't
+# distinguish a file stranded by a dead client from one still in flight on a
+# long-running manifest. HeadObject already returns LastModified, so the object's
+# own age is available without a schema change — see the reconcile lambda.
 
 resource "aws_cloudwatch_event_rule" "reconcile_schedule" {
   name                = "${var.environment_name}-${var.service_name}-reconcile-hourly-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
@@ -160,6 +166,42 @@ resource "aws_cloudwatch_metric_alarm" "orphans_missing" {
   period              = 3600
   statistic           = "Sum"
   threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.reconcile_alerts.arn]
+}
+
+# Sustained recovery activity. In a healthy system the reconciler recovers
+# roughly nothing: a file only reaches it if a client died between its S3 PUT
+# and its finalize call, which the pennsieve-app finalize journal now handles
+# client-side. So a *persistently* nonzero recovery count means something
+# upstream is leaking files, and the reconciler is quietly papering over it.
+#
+# This is the alarm that was missing. `OrphansRecovered` counts successful SQS
+# enqueues, not successful imports, so when 210 files for a deleted dataset were
+# re-enqueued and re-failed every single day for six weeks, the metric reported
+# a healthy-looking 210/day recovery and nothing paged. The only signal was the
+# DLQ alarm, which was written off as noise.
+#
+# Threshold is generous (24 hourly runs; a genuine client crash mid-upload can
+# legitimately strand a few hundred files in one batch) — this is meant to catch
+# a sustained leak, not a one-off.
+#
+# Deliberately keeps period = 86400 while its siblings above moved to 3600 for
+# the hourly cadence. Those alarms answer "did this run go wrong?", which should
+# be evaluated per run. This one answers "has recovery been happening day after
+# day?", so a daily bucket over 3 evaluation periods is the point — at 3600 it
+# would fire on any single busy hour and tell us nothing about a sustained leak.
+resource "aws_cloudwatch_metric_alarm" "orphans_recovered_sustained" {
+  alarm_name          = "${var.environment_name}-${var.service_name}-reconcile-orphans-recovered-sustained-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  alarm_description   = "Reconciler has been recovering orphaned files every day for 3 days. Something upstream is stranding files between S3 PUT and finalize; the sweep is masking it."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  metric_name         = "OrphansRecovered"
+  namespace           = "UploadService/Reconcile"
+  period              = 86400
+  statistic           = "Sum"
+  threshold           = 500
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.reconcile_alerts.arn]
 }


### PR DESCRIPTION
## Problem

Two issues in the orphan reconciler, both found while tracing why users saw uploaded files appear a day or two late. The client-side cause of that report is fixed separately in [pennsieve-app#785](https://github.com/Pennsieve/pennsieve-app/pull/785); this PR fixes what the reconciler itself was doing wrong.

### 1. An infinite re-enqueue loop pinning the DLQ

`resolveManifest` verified the DynamoDB manifest row and the Postgres **org** row, but never the **dataset**. Both survive dataset deletion, so a manifest whose dataset is gone looked perfectly healthy: every run HEADed its objects (still present in S3), re-enqueued them, and the upload lambda failed each one on `packages_dataset_id_fkey`.

In prod, since roughly **2026-06-15**:

| | |
|---|---|
| files looping | **210** across 5 manifests (`2e741f52`, `3397646d`, `72a963d0`, `89fab20d`, `da2f9cb6`) |
| owner | org 367, `dataset_id` 4191 — dataset row deleted |
| FK-violation log lines | ~9,700 per 30 days |
| DLQ depth | **~1,470** = 210/day × 7-day retention |
| alarm | `upload-sqs-deadletter-queue-alarm` firing into VictorOps daily |

The reason nobody caught it: `OrphansRecovered` counts successful SQS **enqueues**, not successful imports. So the metric reported a healthy-looking 210/day recovery for six weeks while the same 210 files failed every single night. The only real signal was the DLQ alarm, which got written off as noise.

### 2. Recovery latency up to ~48h

The sweep ran daily at 07:00 UTC, and the grace check is evaluated against the **manifest's** `DateCreated`. A manifest created a few hours before the run was still inside the 6h window and got skipped entirely — pushing recovery to the *next* day. Measured at **29h** on manifest `faf16746…`.

## Changes

**Dataset existence check.** `resolveManifest` now confirms the dataset via `WithOrg` + `GetDatasetById`. `datasets` lives in the per-org schema and pgdb's `getDataset` issues an unqualified `FROM datasets`, so the search_path has to be set first — safe here because `resolveManifest` only runs on the paginator goroutine (results cached per manifest) and the concurrent HEAD workers never touch Postgres.

**`isManifestNotFound` → `isTerminalResolveError`,** covering both "manifest row gone" and "dataset gone". Terminal failures route to the existing `markFailedOrphan` path, which moves the rows off the `StatusIndex = "Registered"` partition so they are never retried again. Nothing is deleted; no S3 object is touched.

The asymmetry matters and the test enforces it in both directions: a false negative loops forever (what we had), but a **false positive is worse** — it would flip recoverable rows to `FailedOrphan` during a transient Postgres or DynamoDB blip, taking them out of the scan permanently. So Postgres 5xx, throttling, a missing org row, and S3 region-lookup failures all stay transient. Anything not positively known to be terminal is transient.

**Terminal failures no longer counted as errors.** They're expected and handled, so appending them to `result.Errors` would fire the reconcile-errors alarm on every run until the flip completed — training everyone to ignore that alarm. Rows are still counted toward `Missing`.

**Hourly schedule.** `cron(0 7 * * ? *)` → `cron(0 * * * ? *)`, capping worst-case recovery at grace + 1h instead of grace + 24h.

**The alarm that was missing:** sustained nonzero `OrphansRecovered` across 3 consecutive days (threshold 500/day). A healthy reconciler recovers roughly nothing — a persistently nonzero count means something upstream is stranding files and the sweep is masking it, which is precisely what went unnoticed.

## Expect this on the first run after deploy

- **`OrphansMissing` will spike to ~210 once** and the `reconcile-orphans-missing` alarm (threshold 10/day) will fire. That's the 210 stuck rows being flipped to `FailedOrphan`. It should not recur.
- **The DLQ will stay at ~1,470 for up to a week.** This stops new messages; the existing ones age out via `MessageRetentionPeriod` (604800s). Clearing it sooner means a purge, which I'd want signed off separately as a destructive prod action.

## Review notes

- **The EventBridge rule is renamed** (`-reconcile-daily-` → `-reconcile-hourly-`), so the plan will show a destroy/create of the rule plus its target and lambda permission. Brief gap in scheduling during apply; harmless now that it's hourly.
- **No new DB grants needed.** `ConnectRDS()` authenticates as `{ENV}_rds_proxy_user`, the same user every lambda uses, and the upload lambda already reads `datasets` in the org schema as that user.
- `terraform fmt` flags `lambda.tf` for pre-existing `=` misalignment. Untouched — not this PR's business.
- One asymmetry left alone: in **one-shot** mode (`{"manifestNodeId": ...}`), a deleted-dataset manifest now returns a clear error rather than flipping its rows. Better than the silent no-op it was, but it doesn't self-heal; the scheduled sweep handles that.

## Testing

`go build`, `go vet`, `go test` clean in `lambda/reconcile`. New `store_test.go` covers the terminal/transient classification in both directions plus a guard on the `DatasetNotFoundError` assumption — if a pennsieve-go-core bump stops converting `sql.ErrNoRows` to that type, deleted-dataset detection silently breaks with no other test failing.

Verified the test actually catches the bug: stubbing out the `errDatasetGone` branch fails `dataset_gone_sentinel` and `dataset_gone_survives_extra_wrapping`.

## Not included

- **Per-file grace period.** Would let the 6h grace drop much lower. `ManifestFileTable` has no timestamp column, but `HeadObject` already returns `LastModified`, so the object's own age is available without a schema change. Deferred — it changes recovery semantics and deserves its own review.
- **Terminal-error handling in the upload lambda.** An FK violation is retried 3× today; retrying can't succeed. Detecting it and marking the row `FailedOrphan` instead of returning a `batchItemFailure` would stop the DLQ filling even if something re-enqueues. Defence in depth, separate PR.
- **`pq: syntax error at or near "ON"`** — 2 occurrences per 30 days from the package-insert path. Real, unexplained, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
