### PR TITLE
fix(upload): drop heartbeats before connecting to RDS

### DIFF
--- a/lambda/upload/handler/handler.go
+++ b/lambda/upload/handler/handler.go
@@ -96,6 +96,27 @@ func InitializeClients() {
 	ChangelogClient = changelog.NewClient(*SQSClient, JobSQSQueueId)
 }
 
+// filterLiveRecords splits a batch into messages that carry an S3 event and
+// those that do not. Heartbeats are emitted once a minute by the
+// upload_lambda_heartbeat EventBridge rule (modules/upload-service-v2/
+// cloudwatch.tf in clin-infrastructure) purely to keep the SQS pollers and
+// the execution environment warm; they carry no S3 Records. Anything else
+// unparseable is dropped by the same guard so the Records[0] accesses
+// downstream stay safe.
+func filterLiveRecords(records []events.SQSMessage) ([]events.SQSMessage, int) {
+	live := records[:0]
+	dropped := 0
+	for _, m := range records {
+		parsedS3Event := events.S3Event{}
+		if err := json.Unmarshal([]byte(m.Body), &parsedS3Event); err != nil || len(parsedS3Event.Records) == 0 {
+			dropped++
+			continue
+		}
+		live = append(live, m)
+	}
+	return live, dropped
+}
+
 // Handler implements the function that is called when new SQS Events arrive.
 func Handler(ctx context.Context, sqsEvent events.SQSEvent) (events.SQSEventResponse, error) {
 
@@ -103,11 +124,28 @@ func Handler(ctx context.Context, sqsEvent events.SQSEvent) (events.SQSEventResp
 		BatchItemFailures: []events.SQSBatchItemFailure{},
 	}
 
+	// Discard heartbeats before touching Postgres. A heartbeat needs no
+	// database, and connecting anyway had two costs: ~43k RDS connections a
+	// month for warmth pings, and — worse — during an RDS outage every ping
+	// failed and landed in the DLQ, so the DLQ alarm paged on a liveness
+	// signal instead of on real upload failures.
+	liveRecords, heartbeatCount := filterLiveRecords(sqsEvent.Records)
+	if heartbeatCount > 0 {
+		log.Debugf("Dropped %d heartbeat/non-S3 message(s) from batch", heartbeatCount)
+	}
+	if len(liveRecords) == 0 {
+		return eventResponse, nil
+	}
+	sqsEvent.Records = liveRecords
+
+	// db.Close() must be deferred only after the error check: ConnectRDS
+	// returns a nil *sql.DB on failure, and Close() on that panics with a
+	// nil-pointer dereference, replacing the real error with a stack trace.
 	db, err := pgQueries.ConnectRDS()
-	defer db.Close()
 	if err != nil {
 		return eventResponse, err
 	}
+	defer db.Close()
 
 	// Define store without Postgres connection (as this is different depending on the manifest/org)
 	s := NewUploadHandlerStore(

--- a/lambda/upload/handler/heartbeat_test.go
+++ b/lambda/upload/handler/heartbeat_test.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testS3Body = `{"Records":[{"s3":{"bucket":{"name":"some-bucket"},"object":{"key":"some/key","size":10}}}]}`
+
+func TestFilterLiveRecords(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		bodies      []string
+		wantLive    int
+		wantDropped int
+	}{
+		{
+			name:        "heartbeat only",
+			bodies:      []string{`{"heartbeat":true}`},
+			wantLive:    0,
+			wantDropped: 1,
+		},
+		{
+			name:        "s3 event only",
+			bodies:      []string{testS3Body},
+			wantLive:    1,
+			wantDropped: 0,
+		},
+		{
+			name:        "heartbeat mixed with s3 event",
+			bodies:      []string{`{"heartbeat":true}`, testS3Body, `{"heartbeat":true}`},
+			wantLive:    1,
+			wantDropped: 2,
+		},
+		{
+			name:        "malformed json is dropped",
+			bodies:      []string{`not json at all`, testS3Body},
+			wantLive:    1,
+			wantDropped: 1,
+		},
+		{
+			name:        "s3 envelope with no records is dropped",
+			bodies:      []string{`{"Records":[]}`},
+			wantLive:    0,
+			wantDropped: 1,
+		},
+		{
+			name:        "empty batch",
+			bodies:      nil,
+			wantLive:    0,
+			wantDropped: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			records := make([]events.SQSMessage, 0, len(tt.bodies))
+			for _, b := range tt.bodies {
+				records = append(records, events.SQSMessage{Body: b})
+			}
+
+			live, dropped := filterLiveRecords(records)
+
+			assert.Len(t, live, tt.wantLive)
+			assert.Equal(t, tt.wantDropped, dropped)
+			for _, m := range live {
+				assert.NotEqual(t, `{"heartbeat":true}`, m.Body,
+					"a heartbeat survived the filter")
+			}
+		})
+	}
+}
+
+// TestHandlerSkipsDatabaseForHeartbeatOnlyBatch guards the ordering in
+// Handler: heartbeats must be discarded before ConnectRDS is called. When
+// that ordering regressed, every once-a-minute heartbeat opened a Postgres
+// connection, and an RDS outage sent the whole heartbeat stream to the DLQ —
+// paging on a warmth signal rather than on a real upload failure.
+func TestHandlerSkipsDatabaseForHeartbeatOnlyBatch(t *testing.T) {
+	resp, err := Handler(context.Background(), events.SQSEvent{
+		Records: []events.SQSMessage{
+			{MessageId: "hb-1", Body: `{"heartbeat":true}`},
+			{MessageId: "hb-2", Body: `{"heartbeat":true}`},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.BatchItemFailures,
+		"heartbeats must be acknowledged, never returned as batch item failures")
+}

--- a/lambda/upload/handler/store.go
+++ b/lambda/upload/handler/store.go
@@ -443,23 +443,11 @@ func (s *UploadHandlerStore) Handler(ctx context.Context, sqsEvent events.SQSEve
 		BatchItemFailures: batchItemFailures,
 	}
 
-	// Drop heartbeat + malformed records up front. Heartbeats are emitted
-	// by the upload_lambda_heartbeat EventBridge rule (see terraform/
-	// cloudwatch.tf) to keep SQS pollers and the lambda execution
-	// environment warm during idle periods — they have no S3 Records
-	// payload and must be ack'd without processing. The same guard also
-	// hardens the Records[0] access below against any other non-S3
-	// message that might reach this queue.
-	liveRecords := sqsEvent.Records[:0]
-	heartbeatCount := 0
-	for _, m := range sqsEvent.Records {
-		parsedS3Event := events.S3Event{}
-		if err := json.Unmarshal([]byte(m.Body), &parsedS3Event); err != nil || len(parsedS3Event.Records) == 0 {
-			heartbeatCount++
-			continue
-		}
-		liveRecords = append(liveRecords, m)
-	}
+	// Drop heartbeat + malformed records up front. Normally Handler in
+	// handler.go has already done this before opening a Postgres
+	// connection; this repeats it so the Records[0] access below stays
+	// safe for any caller that reaches us directly (tests included).
+	liveRecords, heartbeatCount := filterLiveRecords(sqsEvent.Records)
 	if heartbeatCount > 0 {
 		log.Debugf("Dropped %d heartbeat/non-S3 message(s) from batch", heartbeatCount)
 	}


### PR DESCRIPTION
## What

`Handler` in `lambda/upload/handler/handler.go` called `ConnectRDS()` as its
first action, before looking at the batch at all. This moves the existing
heartbeat filter ahead of that call, and fixes the error handling that hid the
resulting failures.

## Why

Found while debugging a DLQ alarm on clin prod. Two separate problems compounded:

**1. Heartbeats were hitting Postgres.** The `upload_lambda_heartbeat`
EventBridge rule pings `upload_trigger_queue` once a minute with
`{"heartbeat":true}` purely to keep the SQS pollers and execution environment
warm. The comment on that rule says the handler "detects heartbeat messages by
their missing S3 Records and returns without processing" — but that filter lived
in `store.Handler`, which is only reachable *after* a database connection is
established. So every ping opened an RDS connection it never used, ~43k/month.

Worse, when RDS was unreachable every heartbeat failed and retried into the DLQ.
The DLQ alarm then fired on a liveness ping rather than on any real upload
failure: 233 messages accumulated over ~4 hours, every single one a heartbeat,
with no uploads in flight the entire time. The alarm was real but pointed at the
wrong thing, and the DLQ had to be purged rather than redriven.

**2. The real error was masked by a panic.**

```go
db, err := pgQueries.ConnectRDS()
defer db.Close()   // db is nil here when err != nil
if err != nil {
    return eventResponse, err
}
```

`ConnectRDS` returns a nil `*sql.DB` on failure, so the deferred `Close()`
panicked with `invalid memory address or nil pointer dereference` and replaced
the returned error. Every log line showed the same useless stack trace. The
actual cause — `pq: This RDS proxy has no credentials for the role
prod_rds_proxy_user` — was only visible from the reconcile lambda, which happens
to check `err` before deferring.

## Changes

- Extract the heartbeat/non-S3 filter into a package-level `filterLiveRecords()`
- Call it in `Handler` before `ConnectRDS`, returning early on an all-heartbeat batch
- `store.Handler` still applies the same filter, so direct callers and tests stay safe
- Move `defer db.Close()` below the error check
- Add `heartbeat_test.go`: table-driven coverage of the filter, plus a regression
  test asserting `Handler` returns cleanly for a heartbeat-only batch without a database

## Testing

`make test-ci` green (full suite, exit 0). Targeted run:

```
--- PASS: TestFilterLiveRecords (0.01s)
    --- PASS: TestFilterLiveRecords/heartbeat_only
    --- PASS: TestFilterLiveRecords/s3_event_only
    --- PASS: TestFilterLiveRecords/heartbeat_mixed_with_s3_event
    --- PASS: TestFilterLiveRecords/malformed_json_is_dropped
    --- PASS: TestFilterLiveRecords/s3_envelope_with_no_records_is_dropped
    --- PASS: TestFilterLiveRecords/empty_batch
--- PASS: TestHandlerSkipsDatabaseForHeartbeatOnlyBatch (0.00s)
ok  	github.com/pennsieve/pennsieve-upload-service-v2/upload/handler	6.444s
```

Note: the underlying clin RDS proxy credential issue is fixed separately (the
proxy secret needed `username: prod_rds_proxy_user`). This PR does not change
connection behaviour for real uploads — it stops heartbeats from needing a
database, and makes connection failures legible when they do happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)